### PR TITLE
Harden PQ auth flow and improve MainView resiliency

### DIFF
--- a/src/main/java/com/afitnerd/tnra/controller/PQController.java
+++ b/src/main/java/com/afitnerd/tnra/controller/PQController.java
@@ -11,6 +11,7 @@ import org.apache.hc.client5.http.HttpResponseException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.security.Principal;
@@ -49,10 +51,18 @@ public class PQController {
     public Map<String, String> pqAuthenticate(
         Principal me, @RequestBody PQAuthenticationRequest request
     ) throws IOException {
-        // TODO - check presence of login and password
+        if (me == null || !StringUtils.hasText(me.getName())) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authentication required");
+        }
+        if (request == null || !StringUtils.hasText(request.getLogin()) || !StringUtils.hasText(request.getPassword())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "login and password are required");
+        }
+
         PQAuthenticationResponse response = pqService.authenticate(request.getLogin(), request.getPassword());
-//        log.info("pq auth: {}", mapper.writeValueAsString(response));
         User user = userRepository.findByEmail(me.getName());
+        if (user == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Authenticated user not found");
+        }
         user.setPqAccessToken(response.getAccessToken());
         user.setPqRefreshToken(response.getRefreshToken());
         userRepository.save(user);

--- a/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
@@ -15,6 +15,9 @@ import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.Route;
 import com.vaadin.flow.router.RouteAlias;
 import com.vaadin.flow.server.auth.AnonymousAllowed;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
 
 @PageTitle("TNRA - Taking the Next Right Action")
 @Route(value = "", layout = MainLayout.class)
@@ -22,6 +25,8 @@ import com.vaadin.flow.server.auth.AnonymousAllowed;
 @AnonymousAllowed
 @CssImport("./styles/main-view.css")
 public class MainView extends VerticalLayout {
+
+    private static final Logger log = LoggerFactory.getLogger(MainView.class);
 
     private final OidcUserService oidcUserService;
     private final UserService userService;
@@ -77,17 +82,20 @@ public class MainView extends VerticalLayout {
             // Profile Image
             Image profileImage = new Image();
             profileImage.addClassName("main-profile-image");
-            
+            profileImage.setAlt("User profile image");
+
             if (currentUser != null && currentUser.getProfileImage() != null && !currentUser.getProfileImage().isEmpty()) {
                 String imageUrl = fileStorageService.getFileUrl(currentUser.getProfileImage());
-                profileImage.setSrc(imageUrl);
+                profileImage.setSrc(StringUtils.hasText(imageUrl) ? imageUrl : "/uploads/placeholder.png");
             } else {
                 profileImage.setSrc("/uploads/placeholder.png");
             }
-            
+
+            String resolvedDisplayName = resolveDisplayName(displayName, currentUser);
+
             // Welcome Message
             Paragraph welcomeMessage = new Paragraph(
-                "Hello, " + displayName + "! You are now logged in."
+                "Hello, " + resolvedDisplayName + "! You are now logged in."
             );
             welcomeMessage.addClassName("welcome-message");
             
@@ -110,10 +118,27 @@ public class MainView extends VerticalLayout {
             errorMessage.addClassName("error-message");
             
             add(title, welcomeMessage, errorMessage);
-            
-            // Log the error for debugging
-            System.err.println("Error in showAuthenticatedView: " + e.getMessage());
-            e.printStackTrace();
+
+            log.warn("Error while rendering authenticated main view", e);
         }
     }
-} 
+
+    private String resolveDisplayName(String displayName, User currentUser) {
+        if (StringUtils.hasText(displayName)) {
+            return displayName;
+        }
+        if (currentUser == null) {
+            return "there";
+        }
+        if (StringUtils.hasText(currentUser.getFirstName()) && StringUtils.hasText(currentUser.getLastName())) {
+            return currentUser.getFirstName().trim() + " " + currentUser.getLastName().trim();
+        }
+        if (StringUtils.hasText(currentUser.getFirstName())) {
+            return currentUser.getFirstName().trim();
+        }
+        if (StringUtils.hasText(currentUser.getEmail())) {
+            return currentUser.getEmail().trim();
+        }
+        return "there";
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/controller/PQControllerTest.java
+++ b/src/test/java/com/afitnerd/tnra/controller/PQControllerTest.java
@@ -1,0 +1,102 @@
+package com.afitnerd.tnra.controller;
+
+import com.afitnerd.tnra.model.User;
+import com.afitnerd.tnra.model.pq.PQAuthenticationRequest;
+import com.afitnerd.tnra.model.pq.PQAuthenticationResponse;
+import com.afitnerd.tnra.repository.UserRepository;
+import com.afitnerd.tnra.service.pq.PQService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.io.IOException;
+import java.security.Principal;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PQControllerTest {
+
+    @Mock
+    private PQService pqService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private PQController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new PQController(pqService, userRepository);
+    }
+
+    @Test
+    void pqAuthenticateRejectsMissingCredentials() throws IOException {
+        Principal principal = () -> "user@example.com";
+        PQAuthenticationRequest request = new PQAuthenticationRequest();
+        request.setLogin(" ");
+        request.setPassword("secret");
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+            () -> controller.pqAuthenticate(principal, request));
+
+        assertEquals(HttpStatus.BAD_REQUEST, exception.getStatusCode());
+        verify(pqService, never()).authenticate(anyString(), anyString());
+    }
+
+    @Test
+    void pqAuthenticateRejectsUnknownAuthenticatedUser() throws IOException {
+        Principal principal = () -> "user@example.com";
+        PQAuthenticationRequest request = new PQAuthenticationRequest();
+        request.setLogin("login");
+        request.setPassword("password");
+
+        PQAuthenticationResponse response = new PQAuthenticationResponse();
+        response.setAccessToken("access-token");
+        response.setRefreshToken("refresh-token");
+        when(pqService.authenticate("login", "password")).thenReturn(response);
+        when(userRepository.findByEmail("user@example.com")).thenReturn(null);
+
+        ResponseStatusException exception = assertThrows(ResponseStatusException.class,
+            () -> controller.pqAuthenticate(principal, request));
+
+        assertEquals(HttpStatus.UNAUTHORIZED, exception.getStatusCode());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void pqAuthenticateStoresTokensForValidRequest() throws IOException {
+        Principal principal = () -> "user@example.com";
+        User user = new User();
+        user.setEmail("user@example.com");
+
+        PQAuthenticationRequest request = new PQAuthenticationRequest();
+        request.setLogin("login");
+        request.setPassword("password");
+
+        PQAuthenticationResponse response = new PQAuthenticationResponse();
+        response.setAccessToken("access-token");
+        response.setRefreshToken("refresh-token");
+
+        when(pqService.authenticate("login", "password")).thenReturn(response);
+        when(userRepository.findByEmail("user@example.com")).thenReturn(user);
+
+        Map<String, String> result = controller.pqAuthenticate(principal, request);
+
+        assertEquals("SUCCESS", result.get("status"));
+        assertEquals("access-token", user.getPqAccessToken());
+        assertEquals("refresh-token", user.getPqRefreshToken());
+        verify(userRepository).save(user);
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
@@ -14,11 +14,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Optional;
-
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -199,5 +198,42 @@ class MainViewTest {
         // Assert
         assertNotNull(mainView);
         assertTrue(mainView.getChildren().count() > 0);
+    }
+
+    @Test
+    void testMainViewFallsBackToCurrentUserNameWhenDisplayNameMissing() {
+        testUser.setProfileImage(null);
+        when(oidcUserService.isAuthenticated()).thenReturn(true);
+        when(oidcUserService.getDisplayName()).thenReturn(" ");
+        when(userService.getCurrentUser()).thenReturn(testUser);
+
+        mainView = new MainView(oidcUserService, userService, fileStorageService);
+
+        boolean hasFallbackGreeting = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .filter(component -> component instanceof Paragraph)
+            .map(component -> (Paragraph) component)
+            .anyMatch(paragraph -> paragraph.getText().contains("Hello, John Doe!"));
+
+        assertTrue(hasFallbackGreeting, "Expected greeting to use current user name when display name is blank");
+    }
+
+    @Test
+    void testMainViewSetsAccessibleAltTextForProfileImage() {
+        when(oidcUserService.isAuthenticated()).thenReturn(true);
+        when(oidcUserService.getDisplayName()).thenReturn("Test User");
+        when(userService.getCurrentUser()).thenReturn(testUser);
+
+        mainView = new MainView(oidcUserService, userService, fileStorageService);
+
+        Image profileImage = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .filter(component -> component instanceof Image)
+            .map(component -> (Image) component)
+            .findFirst()
+            .orElseThrow();
+
+        assertEquals("User profile image", profileImage.getAlt().orElse(null));
+        verify(fileStorageService).getFileUrl("profile.jpg");
     }
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -2,4 +2,13 @@ tnra.slack.token=my_special_token
 spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL
 tnra.notify.schedule=0 0 12 * * ?
 pq.refresh.schedule=0 52 7 * * ?
-
+spring.security.oauth2.client.registration.okta.client-id=test-client
+spring.security.oauth2.client.registration.okta.client-secret=test-secret
+spring.security.oauth2.client.registration.okta.authorization-grant-type=authorization_code
+spring.security.oauth2.client.registration.okta.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
+spring.security.oauth2.client.registration.okta.scope=openid,profile,email
+spring.security.oauth2.client.provider.okta.authorization-uri=https://example.invalid/oauth2/v1/authorize
+spring.security.oauth2.client.provider.okta.token-uri=https://example.invalid/oauth2/v1/token
+spring.security.oauth2.client.provider.okta.user-info-uri=https://example.invalid/oauth2/v1/userinfo
+spring.security.oauth2.client.provider.okta.user-name-attribute=sub
+spring.security.oauth2.client.provider.okta.jwk-set-uri=https://example.invalid/oauth2/v1/keys


### PR DESCRIPTION
## Summary
- harden `PQController` authentication endpoint with explicit request/principal/user validation and proper HTTP statuses
- improve `MainView` authenticated UX with robust display-name fallbacks and null-safe profile image URL handling
- replace stderr stack traces in `MainView` with structured logger warnings
- add profile image alt text for better accessibility
- add new `PQControllerTest` coverage and extend `MainViewTest`
- add OAuth2 client test properties so Spring context tests can run reliably in test environments

## Testing
- `./mvnw -q -Dtest=MainViewTest,PQControllerTest test`
- `./mvnw test`
