### PR TITLE
Improve test coverage to 70 percent

### DIFF
--- a/src/test/java/com/afitnerd/tnra/config/SpringSecurityConfigTest.java
+++ b/src/test/java/com/afitnerd/tnra/config/SpringSecurityConfigTest.java
@@ -1,0 +1,74 @@
+package com.afitnerd.tnra.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUserAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2UserAuthority;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.security.web.authentication.logout.SimpleUrlLogoutSuccessHandler;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SpringSecurityConfigTest {
+
+    @Test
+    void logoutSuccessHandlerRedirectsHome() {
+        SpringSecurityConfig config = new SpringSecurityConfig();
+
+        LogoutSuccessHandler handler = config.logoutSuccessHandler();
+
+        assertInstanceOf(SimpleUrlLogoutSuccessHandler.class, handler);
+        assertEquals("/", ReflectionTestUtils.getField(handler, "defaultTargetUrl"));
+    }
+
+    @Test
+    void grantedAuthoritiesMapperPreservesExistingAuthoritiesAndExtractsGroups() {
+        SpringSecurityConfig config = new SpringSecurityConfig();
+        GrantedAuthoritiesMapper mapper = config.grantedAuthoritiesMapper();
+        OidcIdToken token = new OidcIdToken(
+            "token",
+            Instant.now(),
+            Instant.now().plusSeconds(60),
+            Map.of("groups", List.of("admin", "ROLE_REPORTS"))
+        );
+        OidcUserAuthority oidcAuthority = new OidcUserAuthority(token);
+
+        Set<String> mapped = mapper.mapAuthorities(Set.of(new SimpleGrantedAuthority("ROLE_USER"), oidcAuthority))
+            .stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(java.util.stream.Collectors.toSet());
+
+        assertTrue(mapped.contains("ROLE_USER"));
+        assertTrue(mapped.contains("ROLE_ADMIN"));
+        assertTrue(mapped.contains("ROLE_REPORTS"));
+    }
+
+    @Test
+    void grantedAuthoritiesMapperFallsBackToRolesAndCommaSeparatedAuthorities() {
+        SpringSecurityConfig config = new SpringSecurityConfig();
+        GrantedAuthoritiesMapper mapper = config.grantedAuthoritiesMapper();
+
+        OAuth2UserAuthority rolesAuthority = new OAuth2UserAuthority(Map.of("roles", List.of("manager")));
+        OAuth2UserAuthority authoritiesAuthority = new OAuth2UserAuthority(Map.of("authorities", "ops, qa"));
+
+        Set<String> mapped = mapper.mapAuthorities(Set.of(rolesAuthority, authoritiesAuthority))
+            .stream()
+            .map(GrantedAuthority::getAuthority)
+            .collect(java.util.stream.Collectors.toSet());
+
+        assertTrue(mapped.contains("ROLE_MANAGER"));
+        assertTrue(mapped.contains("ROLE_OPS"));
+        assertTrue(mapped.contains("ROLE_QA"));
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/controller/APIControllerTest.java
+++ b/src/test/java/com/afitnerd/tnra/controller/APIControllerTest.java
@@ -1,0 +1,128 @@
+package com.afitnerd.tnra.controller;
+
+import com.afitnerd.tnra.model.GoToGuyPair;
+import com.afitnerd.tnra.model.GoToGuySet;
+import com.afitnerd.tnra.model.Post;
+import com.afitnerd.tnra.model.User;
+import com.afitnerd.tnra.repository.GoToGuySetRepository;
+import com.afitnerd.tnra.repository.UserRepository;
+import com.afitnerd.tnra.service.EMailService;
+import com.afitnerd.tnra.service.PostService;
+import com.afitnerd.tnra.service.SlackPostRenderer;
+import com.afitnerd.tnra.slack.service.SlackAPIService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class APIControllerTest {
+
+    @Mock
+    private PostService postService;
+    @Mock
+    private EMailService eMailService;
+    @Mock
+    private SlackAPIService slackAPIService;
+    @Mock
+    private SlackPostRenderer slackPostRenderer;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private GoToGuySetRepository goToGuySetRepository;
+
+    @Test
+    void returnsPrincipalUsersAndLatestGtgSet() {
+        APIController controller = controller();
+        Principal principal = () -> "user@example.com";
+        List<User> users = List.of(new User("A", "User", "a@example.com"));
+        GoToGuySet gtgSet = new GoToGuySet();
+
+        when(userRepository.findByActiveTrue()).thenReturn(users);
+        when(goToGuySetRepository.findTopByOrderByStartDateDesc()).thenReturn(gtgSet);
+
+        assertSame(principal, controller.me(principal));
+        assertSame(users, controller.users());
+        assertSame(gtgSet, controller.gtgLatest());
+    }
+
+    @Test
+    void notifyWhatAndWhensSendsLastFinishedPostsForEachPair() {
+        APIController controller = controller();
+        User caller = new User("Caller", "One", "caller@example.com");
+        User callee = new User("Callee", "Two", "callee@example.com");
+        GoToGuyPair pair = new GoToGuyPair();
+        pair.setCaller(caller);
+        pair.setCallee(callee);
+        GoToGuySet gtgSet = new GoToGuySet();
+        gtgSet.setGoToGuyPairs(List.of(pair));
+        Post callerPost = new Post(caller);
+        Post calleePost = new Post(callee);
+        when(goToGuySetRepository.findTopByOrderByStartDateDesc()).thenReturn(gtgSet);
+        when(postService.getLastFinishedPost(callee)).thenReturn(calleePost);
+        when(postService.getLastFinishedPost(caller)).thenReturn(callerPost);
+
+        GoToGuySet returned = controller.notifyWhatAndWhens();
+
+        assertSame(gtgSet, returned);
+        verify(eMailService).sendTextViaMail(callee, calleePost);
+        verify(eMailService).sendTextViaMail(callee, callerPost);
+    }
+
+    @Test
+    void inProgressCompleteStartAndUpdateUseCurrentUser() {
+        APIController controller = controller();
+        Principal principal = () -> "user@example.com";
+        User user = new User("Test", "User", "user@example.com");
+        Post post = new Post(user);
+        when(userRepository.findByEmail("user@example.com")).thenReturn(user);
+        when(postService.getOptionalInProgressPost(user)).thenReturn(Optional.of(post));
+        when(postService.getOptionalCompletePost(user)).thenReturn(Optional.of(post));
+        when(postService.startPost(user)).thenReturn(post);
+        when(postService.savePost(post)).thenReturn(post);
+
+        assertEquals(Optional.of(post), controller.getInProgressPost(principal));
+        assertSame(post, controller.updatePost(principal, post));
+        assertEquals(Optional.of(post), controller.getCompletePost(principal));
+        assertSame(post, controller.startPost(principal));
+    }
+
+    @Test
+    void finishPostSendsEmailAndSlackMessage() {
+        APIController controller = controller();
+        Principal principal = () -> "user@example.com";
+        User user = new User("Test", "User", "user@example.com");
+        Post post = new Post(user);
+        when(userRepository.findByEmail("user@example.com")).thenReturn(user);
+        when(postService.finishPost(user)).thenReturn(post);
+        when(slackPostRenderer.render(post)).thenReturn("finished");
+
+        Post finished = controller.finishPost(principal);
+
+        assertSame(post, finished);
+        verify(eMailService).sendMailToAll(post);
+        verify(slackAPIService).chat(any(String.class));
+    }
+
+    private APIController controller() {
+        return new APIController(
+            postService,
+            eMailService,
+            slackAPIService,
+            slackPostRenderer,
+            userRepository,
+            goToGuySetRepository
+        );
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/controller/FileControllerTest.java
+++ b/src/test/java/com/afitnerd/tnra/controller/FileControllerTest.java
@@ -1,0 +1,68 @@
+package com.afitnerd.tnra.controller;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FileControllerTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void serveFileReturnsResourceAndContentTypeForReadableFile() throws IOException {
+        FileController controller = new FileController();
+        ReflectionTestUtils.setField(controller, "uploadDir", tempDir.toString());
+        Files.writeString(tempDir.resolve("avatar.png"), "png");
+
+        ResponseEntity<Resource> response = controller.serveFile("avatar.png");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(MediaType.IMAGE_PNG, response.getHeaders().getContentType());
+        assertEquals("inline; filename=\"avatar.png\"", response.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION));
+        assertTrue(response.getBody().exists());
+    }
+
+    @Test
+    void serveFileReturnsNotFoundWhenFileDoesNotExist() {
+        FileController controller = new FileController();
+        ReflectionTestUtils.setField(controller, "uploadDir", tempDir.toString());
+
+        ResponseEntity<Resource> response = controller.serveFile("missing.gif");
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+    }
+
+    @Test
+    void serveFileRejectsDirectoryTraversal() {
+        FileController controller = new FileController();
+        ReflectionTestUtils.setField(controller, "uploadDir", tempDir.toString());
+
+        ResponseEntity<Resource> response = controller.serveFile("../secrets.txt");
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+    }
+
+    @Test
+    void serveFileFallsBackToOctetStreamForUnknownExtension() throws IOException {
+        FileController controller = new FileController();
+        ReflectionTestUtils.setField(controller, "uploadDir", tempDir.toString());
+        Files.writeString(tempDir.resolve("notes.bin"), "data");
+
+        ResponseEntity<Resource> response = controller.serveFile("notes.bin");
+
+        assertEquals(MediaType.APPLICATION_OCTET_STREAM, response.getHeaders().getContentType());
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/model/PostFormattingTest.java
+++ b/src/test/java/com/afitnerd/tnra/model/PostFormattingTest.java
@@ -1,0 +1,90 @@
+package com.afitnerd.tnra.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PostFormattingTest {
+
+    @Test
+    void defaultConstructorStartsInProgressWithStartTime() {
+        Post post = new Post();
+
+        assertEquals(PostState.IN_PROGRESS, post.getState());
+        assertNotNull(post.getStart());
+    }
+
+    @Test
+    void gettersLazilyCreateNestedStructures() {
+        Post post = new Post();
+
+        assertNotNull(post.getIntro());
+        assertNotNull(post.getPersonal());
+        assertNotNull(post.getFamily());
+        assertNotNull(post.getWork());
+        assertNotNull(post.getStats());
+    }
+
+    @Test
+    void toStringRendersUnsetSectionsClearly() {
+        Post post = new Post();
+        post.setIntro(null);
+        post.setPersonal(null);
+        post.setFamily(null);
+        post.setWork(null);
+        post.setStats(null);
+
+        String rendered = post.toString();
+
+        assertTrue(rendered.contains("*Intro not set*"));
+        assertTrue(rendered.contains("*Personal not set*"));
+        assertTrue(rendered.contains("*Family not set*"));
+        assertTrue(rendered.contains("*Work not set*"));
+        assertTrue(rendered.contains("*Stats not set*"));
+    }
+
+    @Test
+    void toStringFormatsConfiguredSectionsAndNormalizesLineBreaks() {
+        Post post = new Post();
+        Intro intro = new Intro();
+        intro.setWidwytk("line1\nline2");
+        intro.setKryptonite("kryptonite");
+        intro.setWhatAndWhen("what");
+        post.setIntro(intro);
+
+        Category personal = new Category();
+        personal.setBest("best");
+        personal.setWorst("worst");
+        post.setPersonal(personal);
+
+        Category family = new Category();
+        family.setBest("family best");
+        family.setWorst("family worst");
+        post.setFamily(family);
+
+        Category work = new Category();
+        work.setBest("work best");
+        work.setWorst("work worst");
+        post.setWork(work);
+
+        Stats stats = new Stats();
+        stats.setExercise(1);
+        stats.setGtg(2);
+        stats.setMeditate(3);
+        stats.setMeetings(4);
+        stats.setPray(5);
+        stats.setRead(6);
+        stats.setSponsor(7);
+        post.setStats(stats);
+
+        String rendered = post.toString();
+
+        assertTrue(rendered.contains("line1\n\tline2"));
+        assertTrue(rendered.contains("\t*Best:* best"));
+        assertTrue(rendered.contains("\t*Worst:* worst"));
+        assertTrue(rendered.contains("*exercise:* 1, *gtg:* 2, *meditate:* 3"));
+        assertTrue(rendered.contains("*sponsor:* 7"));
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/model/pq/PQMeResponseTest.java
+++ b/src/test/java/com/afitnerd/tnra/model/pq/PQMeResponseTest.java
@@ -1,0 +1,29 @@
+package com.afitnerd.tnra.model.pq;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+class PQMeResponseTest {
+
+    @Test
+    void pqResponseExposesNestedMetrics() {
+        PQMeResponse response = new PQMeResponse();
+        PQMeResponse.Pq pq = new PQMeResponse.Pq();
+        pq.setCharge(BigDecimal.valueOf(12.5));
+        pq.setMuscle(BigDecimal.valueOf(7.2));
+        pq.setRepsToday(42);
+        pq.setUpdatedAt(123456789L);
+
+        response.setPq(pq);
+
+        assertSame(pq, response.getPq());
+        assertEquals(BigDecimal.valueOf(12.5), pq.getCharge());
+        assertEquals(BigDecimal.valueOf(7.2), pq.getMuscle());
+        assertEquals(42, pq.getRepsToday());
+        assertEquals(123456789L, pq.getUpdatedAt());
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
@@ -1,0 +1,65 @@
+package com.afitnerd.tnra.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FileStorageServiceImplTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void storeFileCreatesDirectoryAndPreservesExtension() throws IOException {
+        FileStorageServiceImpl service = new FileStorageServiceImpl();
+        ReflectionTestUtils.setField(service, "uploadDir", tempDir.resolve("uploads").toString());
+
+        String fileName = service.storeFile(
+            new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)),
+            "avatar.png",
+            "image/png"
+        );
+
+        assertNotNull(fileName);
+        assertTrue(fileName.endsWith(".png"));
+        Path storedFile = tempDir.resolve("uploads").resolve(fileName);
+        assertTrue(Files.exists(storedFile));
+        assertEquals("hello", Files.readString(storedFile));
+    }
+
+    @Test
+    void deleteFileRemovesExistingFileAndIgnoresInvalidInput() throws IOException {
+        FileStorageServiceImpl service = new FileStorageServiceImpl();
+        ReflectionTestUtils.setField(service, "uploadDir", tempDir.toString());
+
+        Path storedFile = tempDir.resolve("sample.txt");
+        Files.writeString(storedFile, "content");
+
+        service.deleteFile("sample.txt");
+        service.deleteFile("");
+        service.deleteFile(null);
+
+        assertTrue(Files.notExists(storedFile));
+    }
+
+    @Test
+    void getFileUrlReturnsNullForBlankValuesAndPrefixesBaseUrl() {
+        FileStorageServiceImpl service = new FileStorageServiceImpl();
+        ReflectionTestUtils.setField(service, "baseUrl", "/files");
+
+        assertNull(service.getFileUrl(null));
+        assertNull(service.getFileUrl(""));
+        assertEquals("/files/image.webp", service.getFileUrl("image.webp"));
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/service/OidcUserServiceTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/OidcUserServiceTest.java
@@ -1,0 +1,115 @@
+package com.afitnerd.tnra.service;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OidcUserServiceTest {
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getDisplayNamePrefersFullNameThenFallsBackToGivenAndFamilyName() {
+        OidcUser oidcUser = mock(OidcUser.class);
+        when(oidcUser.getFullName()).thenReturn("Full Name");
+        when(oidcUser.getGivenName()).thenReturn("Given");
+        when(oidcUser.getFamilyName()).thenReturn("Family");
+
+        SecurityContextHolder.getContext().setAuthentication(
+            new TestingAuthenticationToken(oidcUser, null, List.of(new SimpleGrantedAuthority("ROLE_USER")))
+        );
+
+        OidcUserService service = new OidcUserService();
+
+        assertEquals("Full Name", service.getDisplayName());
+
+        when(oidcUser.getFullName()).thenReturn("");
+        assertEquals("Given Family", service.getDisplayName());
+    }
+
+    @Test
+    void getDisplayNameFallsBackToAuthenticationNameWhenNamesMissing() {
+        OidcUser oidcUser = mock(OidcUser.class);
+        when(oidcUser.getFullName()).thenReturn(null);
+        when(oidcUser.getGivenName()).thenReturn(null);
+        when(oidcUser.getFamilyName()).thenReturn(null);
+
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(
+            oidcUser,
+            null,
+            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        authentication.setAuthenticated(true);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        OidcUserService service = new OidcUserService();
+
+        assertEquals(authentication.getName(), service.getDisplayName());
+    }
+
+    @Test
+    void getEmailAndAuthenticationChecksUseCurrentPrincipal() {
+        OidcUser oidcUser = mock(OidcUser.class);
+        when(oidcUser.getEmail()).thenReturn("user@example.com");
+
+        TestingAuthenticationToken authentication = new TestingAuthenticationToken(
+            oidcUser,
+            null,
+            List.of(new SimpleGrantedAuthority("ROLE_USER"))
+        );
+        authentication.setAuthenticated(true);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        OidcUserService service = new OidcUserService();
+
+        assertEquals("user@example.com", service.getEmail());
+        assertTrue(service.isAuthenticated());
+        assertFalse(service.isOidcUser(authentication));
+    }
+
+    @Test
+    void getAttributeReadsOauth2AuthenticationAttributes() {
+        OAuth2User oauth2User = mock(OAuth2User.class);
+        when(oauth2User.getAttribute("department")).thenReturn("engineering");
+        OAuth2AuthenticationToken authentication = mock(OAuth2AuthenticationToken.class, Mockito.RETURNS_DEEP_STUBS);
+        when(authentication.getPrincipal()).thenReturn(oauth2User);
+
+        OidcUserService service = new OidcUserService();
+
+        assertEquals("engineering", service.getAttribute(authentication, "department"));
+        assertTrue(service.isOidcUser(authentication));
+        assertNull(service.getAttribute(new TestingAuthenticationToken("user", null), "department"));
+    }
+
+    @Test
+    void isAuthenticatedRejectsAnonymousOrMissingAuthentication() {
+        SecurityContextHolder.clearContext();
+        OidcUserService noAuthService = new OidcUserService();
+        assertFalse(noAuthService.isAuthenticated());
+
+        TestingAuthenticationToken anonymous = new TestingAuthenticationToken("anonymousUser", null);
+        anonymous.setAuthenticated(true);
+        SecurityContextHolder.getContext().setAuthentication(anonymous);
+
+        OidcUserService anonymousService = new OidcUserService();
+        assertFalse(anonymousService.isAuthenticated());
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/service/UserServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/UserServiceImplTest.java
@@ -1,0 +1,103 @@
+package com.afitnerd.tnra.service;
+
+import com.afitnerd.tnra.model.User;
+import com.afitnerd.tnra.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void getCurrentUserReturnsExistingOidcBackedUser() {
+        OidcUser oidcUser = org.mockito.Mockito.mock(OidcUser.class);
+        when(oidcUser.getEmail()).thenReturn("user@example.com");
+        when(oidcUser.getGivenName()).thenReturn("Test");
+        when(oidcUser.getFamilyName()).thenReturn("User");
+        User existing = new User("Test", "User", "user@example.com");
+        when(userRepository.findByEmail("user@example.com")).thenReturn(existing);
+        SecurityContextHolder.getContext().setAuthentication(
+            new TestingAuthenticationToken(oidcUser, null, List.of(new SimpleGrantedAuthority("ROLE_USER")))
+        );
+
+        UserServiceImpl service = new UserServiceImpl(userRepository);
+
+        assertSame(existing, service.getCurrentUser());
+    }
+
+    @Test
+    void getCurrentUserCreatesActiveUserWhenMissing() {
+        OidcUser oidcUser = org.mockito.Mockito.mock(OidcUser.class);
+        when(oidcUser.getEmail()).thenReturn("new.user@example.com");
+        when(oidcUser.getGivenName()).thenReturn("New");
+        when(oidcUser.getFamilyName()).thenReturn("User");
+        when(userRepository.findByEmail("new.user@example.com")).thenReturn(null);
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        SecurityContextHolder.getContext().setAuthentication(
+            new TestingAuthenticationToken(oidcUser, null, List.of(new SimpleGrantedAuthority("ROLE_USER")))
+        );
+
+        UserServiceImpl service = new UserServiceImpl(userRepository);
+        User user = service.getCurrentUser();
+
+        assertNotNull(user);
+        assertEquals("new.user@example.com", user.getEmail());
+        assertEquals("New", user.getFirstName());
+        assertEquals("User", user.getLastName());
+        assertEquals("oidc-new.user@example.com", user.getSlackUserId());
+        assertEquals("new.user", user.getSlackUsername());
+        assertEquals(Boolean.TRUE, user.getActive());
+        verify(userRepository).save(any(User.class));
+    }
+
+    @Test
+    void getCurrentUserReturnsNullWithoutOidcAuthentication() {
+        SecurityContextHolder.clearContext();
+        UserServiceImpl service = new UserServiceImpl(userRepository);
+
+        assertNull(service.getCurrentUser());
+    }
+
+    @Test
+    void delegatesSaveDeleteAndActiveUserQueries() {
+        UserServiceImpl service = new UserServiceImpl(userRepository);
+        User user = new User();
+        List<User> activeUsers = List.of(new User("One", "User", "one@example.com"));
+        when(userRepository.save(user)).thenReturn(user);
+        when(userRepository.findByActiveTrueOrderByFirstName()).thenReturn(activeUsers);
+
+        assertSame(user, service.saveUser(user));
+        assertSame(activeUsers, service.getAllActiveUsers());
+        service.deleteUser(user);
+        service.deleteUser(null);
+
+        verify(userRepository).delete(user);
+        verify(userRepository, never()).delete(null);
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/service/pq/PQRendererTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/pq/PQRendererTest.java
@@ -1,0 +1,58 @@
+package com.afitnerd.tnra.service.pq;
+
+import com.afitnerd.tnra.model.pq.PQMeResponse;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PQRendererTest {
+
+    @Test
+    void calcChargeNeverDropsBelowZero() {
+        long longAgo = System.currentTimeMillis() - (60L * 60L * 1000L);
+
+        assertEquals(0L, PQRenderer.calcCharge(1.0, longAgo));
+    }
+
+    @Test
+    void padHelpersRespectRequestedDirectionAndMinimumLength() {
+        assertEquals("abc", PQRenderer.pad("abc", 2, ""));
+        assertEquals("  abc", PQRenderer.padLeft("abc", 5));
+        assertEquals("abc  ", PQRenderer.padRight("abc", 5));
+    }
+
+    @Test
+    void renderRoundsValuesSortsNamesAndMarksWinners() {
+        long now = System.currentTimeMillis();
+        Map<String, PQMeResponse> metrics = new LinkedHashMap<>();
+        metrics.put("Zed", response(9.6, 7.2, 8, now));
+        metrics.put("Alice", response(10.2, 6.4, 9, now));
+        metrics.put("Nobody", null);
+
+        String rendered = PQRenderer.render(metrics);
+
+        assertTrue(rendered.startsWith("```\n"));
+        assertTrue(rendered.endsWith("```"));
+        assertTrue(rendered.contains("Name"));
+        assertTrue(rendered.indexOf("Alice") < rendered.indexOf("Zed"));
+        assertTrue(rendered.contains("*10"));
+        assertTrue(rendered.contains("*7"));
+        assertTrue(rendered.contains("*9"));
+    }
+
+    private static PQMeResponse response(double charge, double muscle, int reps, long updatedAt) {
+        PQMeResponse response = new PQMeResponse();
+        PQMeResponse.Pq pq = new PQMeResponse.Pq();
+        pq.setCharge(BigDecimal.valueOf(charge));
+        pq.setMuscle(BigDecimal.valueOf(muscle));
+        pq.setRepsToday(reps);
+        pq.setUpdatedAt(updatedAt);
+        response.setPq(pq);
+        return response;
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/service/pq/PQServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/pq/PQServiceImplTest.java
@@ -1,0 +1,137 @@
+package com.afitnerd.tnra.service.pq;
+
+import com.afitnerd.tnra.model.User;
+import com.afitnerd.tnra.model.pq.PQAuthenticationResponse;
+import com.afitnerd.tnra.model.pq.PQMeResponse;
+import com.afitnerd.tnra.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PQServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Test
+    void refreshAuthClearsTokensWhenRefreshTokenMissing() {
+        PQServiceImpl service = new PQServiceImpl(userRepository);
+        User user = new User();
+        user.setId(1L);
+        user.setPqAccessToken("access");
+
+        service.refreshAuth(user);
+
+        assertNull(user.getPqAccessToken());
+        assertNull(user.getPqRefreshToken());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void refreshAuthStoresNewTokensOnSuccess() throws IOException {
+        PQServiceImpl service = spy(new PQServiceImpl(userRepository));
+        User user = new User();
+        user.setId(2L);
+        user.setPqRefreshToken("refresh");
+        PQAuthenticationResponse response = new PQAuthenticationResponse();
+        response.setAccessToken("new-access");
+        response.setRefreshToken("new-refresh");
+        doReturn(response).when(service).refresh("refresh");
+
+        service.refreshAuth(user);
+
+        assertEquals("new-access", user.getPqAccessToken());
+        assertEquals("new-refresh", user.getPqRefreshToken());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void refreshAuthClearsTokensWhenRefreshFails() throws IOException {
+        PQServiceImpl service = spy(new PQServiceImpl(userRepository));
+        User user = new User();
+        user.setId(3L);
+        user.setPqAccessToken("old-access");
+        user.setPqRefreshToken("old-refresh");
+        doThrow(new IOException("boom")).when(service).refresh("old-refresh");
+
+        service.refreshAuth(user);
+
+        assertNull(user.getPqAccessToken());
+        assertNull(user.getPqRefreshToken());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void pqMetricsAllReturnsNullWhenUserHasNoAccessToken() {
+        PQServiceImpl service = new PQServiceImpl(userRepository);
+        User user = new User("No", "Token", "no@example.com");
+        when(userRepository.findAll()).thenReturn(List.of(user));
+
+        Map<String, PQMeResponse> result = service.pqMetricsAll();
+
+        assertEquals(1, result.size());
+        assertNull(result.get("No Token"));
+    }
+
+    @Test
+    void pqMetricsAllRefreshesAndRetriesOnce() throws IOException {
+        PQServiceImpl service = spy(new PQServiceImpl(userRepository));
+        User user = new User("Retry", "User", "retry@example.com");
+        user.setId(4L);
+        user.setPqAccessToken("stale");
+        user.setPqRefreshToken("refresh");
+        when(userRepository.findAll()).thenReturn(List.of(user));
+        doThrow(new IOException("stale")).when(service).metrics("stale");
+        doAnswer(invocation -> {
+            user.setPqAccessToken("fresh");
+            return null;
+        }).when(service).refreshAuth(user);
+        PQMeResponse metrics = new PQMeResponse();
+        PQMeResponse.Pq pq = new PQMeResponse.Pq();
+        pq.setCharge(BigDecimal.ONE);
+        metrics.setPq(pq);
+        doReturn(metrics).when(service).metrics("fresh");
+
+        Map<String, PQMeResponse> result = service.pqMetricsAll();
+
+        assertSame(metrics, result.get("Retry User"));
+    }
+
+    @Test
+    void pqMetricsAllClearsTokensAfterRetryFailure() throws IOException {
+        PQServiceImpl service = spy(new PQServiceImpl(userRepository));
+        User user = new User("Fail", "User", "fail@example.com");
+        user.setId(5L);
+        user.setPqAccessToken("stale");
+        user.setPqRefreshToken("refresh");
+        when(userRepository.findAll()).thenReturn(List.of(user));
+        doThrow(new IOException("still stale")).when(service).metrics("stale");
+        doNothing().when(service).refreshAuth(user);
+
+        Map<String, PQMeResponse> result = service.pqMetricsAll();
+
+        assertNull(result.get("Fail User"));
+        assertNull(user.getPqAccessToken());
+        assertNull(user.getPqRefreshToken());
+        verify(userRepository).save(user);
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/slack/controller/SlackControllerTest.java
+++ b/src/test/java/com/afitnerd/tnra/slack/controller/SlackControllerTest.java
@@ -1,0 +1,134 @@
+package com.afitnerd.tnra.slack.controller;
+
+import com.afitnerd.tnra.exception.PostException;
+import com.afitnerd.tnra.service.pq.PQService;
+import com.afitnerd.tnra.slack.model.SlackSlashCommandRequest;
+import com.afitnerd.tnra.slack.model.SlackSlashCommandResponse;
+import com.afitnerd.tnra.slack.service.SlackAPIService;
+import com.afitnerd.tnra.slack.service.SlackSlashCommandService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SlackControllerTest {
+
+    @Mock
+    private SlackSlashCommandService slackSlashCommandService;
+    @Mock
+    private SlackAPIService slackAPIService;
+    @Mock
+    private PQService pqService;
+
+    private SlackController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new SlackController(slackSlashCommandService, slackAPIService, pqService);
+        lenient().when(slackSlashCommandService.isValidToken(any(SlackSlashCommandRequest.class))).thenReturn(false);
+    }
+
+    @Test
+    void postRejectsInvalidSlackToken() {
+        SlackSlashCommandRequest request = request("/post", "show");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> controller.post(request));
+
+        assertEquals("Slack token is incorrect.", exception.getMessage());
+    }
+
+    @Test
+    void pqRejectsInvalidSlackTokenBeforeAsyncWork() {
+        SlackSlashCommandRequest request = request("/pq", "");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> controller.pq(request));
+
+        assertEquals("Slack token is incorrect.", exception.getMessage());
+    }
+
+    @Test
+    void helpRewritesToPostHelpCommand() {
+        SlackSlashCommandRequest request = request("/tnra", "ignored");
+
+        assertThrows(IllegalArgumentException.class, () -> controller.help(request));
+
+        assertEquals("/post", request.getCommand());
+        assertEquals("help", request.getText());
+    }
+
+    @Test
+    void shortcutCommandPrefixesExistingText() {
+        SlackSlashCommandRequest request = request("/show", "status");
+
+        assertThrows(IllegalArgumentException.class, () -> controller.sho(request));
+
+        assertEquals("/post", request.getCommand());
+        assertEquals("show status", request.getText());
+    }
+
+    @Test
+    void introShortcutRewritesToIntroUpdateCommand() {
+        SlackSlashCommandRequest request = request("/wid", "focus");
+
+        assertThrows(IllegalArgumentException.class, () -> controller.wid(request));
+
+        assertEquals("/post", request.getCommand());
+        assertEquals("upd int wid focus", request.getText());
+    }
+
+    @Test
+    void categoryShortcutRewritesToCategoryUpdateCommand() {
+        SlackSlashCommandRequest request = request("/per", "best day");
+
+        assertThrows(IllegalArgumentException.class, () -> controller.per(request));
+
+        assertEquals("/post", request.getCommand());
+        assertEquals("upd per best day", request.getText());
+    }
+
+    @Test
+    void staShortcutRewritesToStatsUpdateCommand() {
+        SlackSlashCommandRequest request = request("/sta", "exe:3");
+
+        assertThrows(IllegalArgumentException.class, () -> controller.sta(request));
+
+        assertEquals("/post", request.getCommand());
+        assertEquals("upd sta exe:3", request.getText());
+    }
+
+    @Test
+    void staSpecificShortcutRewritesToNamedStatUpdateCommand() {
+        SlackSlashCommandRequest request = request("/med", "2");
+
+        assertThrows(IllegalArgumentException.class, () -> controller.staSpecific(request));
+
+        assertEquals("/post", request.getCommand());
+        assertEquals("upd sta med:2", request.getText());
+    }
+
+    @Test
+    void exceptionHandlerReturnsMessageAsSlackResponse() {
+        SlackSlashCommandResponse response = controller.handleException(
+            new PostException("bad command"),
+            null
+        );
+
+        assertEquals("bad command", response.getText());
+    }
+
+    private static SlackSlashCommandRequest request(String command, String text) {
+        SlackSlashCommandRequest request = new SlackSlashCommandRequest();
+        request.setCommand(command);
+        request.setText(text);
+        request.setToken("bad-token");
+        return request;
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/slack/model/SlackSlashCommandRequestTest.java
+++ b/src/test/java/com/afitnerd/tnra/slack/model/SlackSlashCommandRequestTest.java
@@ -1,0 +1,41 @@
+package com.afitnerd.tnra.slack.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SlackSlashCommandRequestTest {
+
+    @Test
+    void gettersToStringAndCommandStringExposeAllFields() {
+        SlackSlashCommandRequest request = new SlackSlashCommandRequest();
+        request.setToken("token");
+        request.setCommand("/post");
+        request.setText("show");
+        request.setTeamId("team-id");
+        request.setTeamDomain("team-domain");
+        request.setChannelId("channel-id");
+        request.setChannelName("channel-name");
+        request.setUserId("user-id");
+        request.setUserName("user-name");
+        request.setResponseUrl("https://example.com/response");
+        request.setTriggerId("trigger-id");
+
+        assertEquals("token", request.getToken());
+        assertEquals("/post", request.getCommand());
+        assertEquals("show", request.getText());
+        assertEquals("team-id", request.getTeamId());
+        assertEquals("team-domain", request.getTeamDomain());
+        assertEquals("channel-id", request.getChannelId());
+        assertEquals("channel-name", request.getChannelName());
+        assertEquals("user-id", request.getUserId());
+        assertEquals("user-name", request.getUserName());
+        assertEquals("https://example.com/response", request.getResponseUrl());
+        assertEquals("trigger-id", request.getTriggerId());
+        assertEquals("/post show\n", request.commandString());
+        assertEquals(
+            "token|/post|show|team-id|team-domain|channel-id|channel-name|user-id|user-name|https://example.com/response",
+            request.toString()
+        );
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/slack/model/SlackSlashCommandResponseTest.java
+++ b/src/test/java/com/afitnerd/tnra/slack/model/SlackSlashCommandResponseTest.java
@@ -1,0 +1,35 @@
+package com.afitnerd.tnra.slack.model;
+
+import com.afitnerd.tnra.slack.model.attachment.BasicAttachment;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SlackSlashCommandResponseTest {
+
+    @Test
+    void responseTypeEnumMapsKnownValuesAndRejectsUnknownOnes() {
+        assertEquals(SlackSlashCommandResponse.ResponseType.EPHEMERAL,
+            SlackSlashCommandResponse.ResponseType.fromValue("ephemeral"));
+        assertEquals(SlackSlashCommandResponse.ResponseType.IN_CHANNEL,
+            SlackSlashCommandResponse.ResponseType.fromValue("in_channel"));
+        assertThrows(IllegalArgumentException.class,
+            () -> SlackSlashCommandResponse.ResponseType.fromValue("unknown"));
+    }
+
+    @Test
+    void responseStoresTextAttachmentsAndResponseType() {
+        SlackSlashCommandResponse response = new SlackSlashCommandResponse();
+        BasicAttachment attachment = new BasicAttachment("Title", "Text");
+
+        response.setText("done");
+        response.addAttachment(attachment);
+        response.setResponseType(SlackSlashCommandResponse.ResponseType.IN_CHANNEL);
+
+        assertEquals("done", response.getText());
+        assertEquals(1, response.getAttachments().size());
+        assertEquals(attachment, response.getAttachments().getFirst());
+        assertEquals("in_channel", response.getResponseType());
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/slack/model/attachment/BasicAttachmentTest.java
+++ b/src/test/java/com/afitnerd/tnra/slack/model/attachment/BasicAttachmentTest.java
@@ -1,0 +1,49 @@
+package com.afitnerd.tnra.slack.model.attachment;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class BasicAttachmentTest {
+
+    @Test
+    void twoArgumentConstructorSetsTitleAndTextOnly() {
+        BasicAttachment attachment = new BasicAttachment("Title", "Body");
+
+        assertEquals("Title", attachment.getTitle());
+        assertEquals("Body", attachment.getText());
+        assertNull(attachment.getPretext());
+        assertNull(attachment.getMarkdownIn());
+    }
+
+    @Test
+    void threeArgumentConstructorSetsPretext() {
+        BasicAttachment attachment = new BasicAttachment("Title", "Pre", "Body");
+
+        assertEquals("Pre", attachment.getPretext());
+        assertNull(attachment.getMarkdownIn());
+    }
+
+    @Test
+    void varargsConstructorLowerCasesMarkdownEnums() {
+        BasicAttachment attachment = new BasicAttachment(
+            "Title",
+            "Pre",
+            "Body",
+            Attachment.MarkdownIn.PRETEXT,
+            Attachment.MarkdownIn.TEXT
+        );
+
+        assertEquals(List.of("pretext", "text"), attachment.getMarkdownIn());
+    }
+
+    @Test
+    void varargsConstructorAllowsNullMarkdownList() {
+        BasicAttachment attachment = new BasicAttachment("Title", "Pre", "Body", (Attachment.MarkdownIn[]) null);
+
+        assertNull(attachment.getMarkdownIn());
+    }
+}


### PR DESCRIPTION
## Summary
- add focused unit tests for controllers, services, PQ helpers, security config, and Slack request/response models
- cover formatting and lazy-init behavior in post and attachment models
- raise JaCoCo line coverage above the 70% target without changing production code

## Verification
- mvn verify
- JaCoCo line coverage: 2001/2856 = 70.06%