### PR TITLE
Harden auth/file path handling and improve authenticated home UX

### DIFF
--- a/src/main/java/com/afitnerd/tnra/service/AuthNavigationService.java
+++ b/src/main/java/com/afitnerd/tnra/service/AuthNavigationService.java
@@ -7,6 +7,9 @@ import org.springframework.util.StringUtils;
 @Service
 public class AuthNavigationService {
 
+    private static final String DEFAULT_REGISTRATION_ID = "okta";
+    private static final String OAUTH_LOGIN_PREFIX = "/oauth2/authorization/";
+
     private final String loginPath;
 
     public AuthNavigationService(
@@ -23,10 +26,28 @@ public class AuthNavigationService {
     static String resolveLoginPath(String configuredLoginPath, String registrationId) {
         if (StringUtils.hasText(configuredLoginPath)) {
             String path = configuredLoginPath.trim();
-            return path.startsWith("/") ? path : "/" + path;
+            String normalizedPath = path.startsWith("/") ? path : "/" + path;
+
+            // Prevent protocol-relative redirects like "//evil.example".
+            if (normalizedPath.startsWith("//")) {
+                return OAUTH_LOGIN_PREFIX + resolveRegistrationId(registrationId);
+            }
+            return normalizedPath;
         }
 
-        String safeRegistrationId = StringUtils.hasText(registrationId) ? registrationId.trim() : "okta";
-        return "/oauth2/authorization/" + safeRegistrationId;
+        return OAUTH_LOGIN_PREFIX + resolveRegistrationId(registrationId);
+    }
+
+    private static String resolveRegistrationId(String registrationId) {
+        if (!StringUtils.hasText(registrationId)) {
+            return DEFAULT_REGISTRATION_ID;
+        }
+
+        String trimmedRegistrationId = registrationId.trim();
+        if (!trimmedRegistrationId.matches("[A-Za-z0-9_-]+")) {
+            return DEFAULT_REGISTRATION_ID;
+        }
+
+        return trimmedRegistrationId;
     }
 }

--- a/src/main/java/com/afitnerd/tnra/service/FileStorageServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/FileStorageServiceImpl.java
@@ -3,6 +3,8 @@ package com.afitnerd.tnra.service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,6 +16,8 @@ import java.util.UUID;
 
 @Service
 public class FileStorageServiceImpl implements FileStorageService {
+
+    private static final Logger log = LoggerFactory.getLogger(FileStorageServiceImpl.class);
 
     @Value("${app.file-storage.upload-dir:uploads}")
     private String uploadDir;
@@ -45,14 +49,23 @@ public class FileStorageServiceImpl implements FileStorageService {
 
     @Override
     public void deleteFile(String fileName) {
-        if (fileName != null && !fileName.isEmpty()) {
-            try {
-                Path filePath = Paths.get(uploadDir, fileName);
-                Files.deleteIfExists(filePath);
-            } catch (IOException e) {
-                // Log error but don't throw - file might already be deleted
-                System.err.println("Error deleting file: " + fileName + " - " + e.getMessage());
-            }
+        if (!StringUtils.hasText(fileName)) {
+            return;
+        }
+
+        Path uploadPath = Paths.get(uploadDir).toAbsolutePath().normalize();
+        Path filePath = uploadPath.resolve(fileName).normalize();
+
+        if (!filePath.startsWith(uploadPath)) {
+            log.warn("Rejected delete request outside upload directory for fileName={}", fileName);
+            return;
+        }
+
+        try {
+            Files.deleteIfExists(filePath);
+        } catch (IOException e) {
+            // Log error but don't throw - file might already be deleted or locked
+            log.warn("Error deleting file={}", fileName, e);
         }
     }
 

--- a/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
@@ -116,8 +116,16 @@ public class MainView extends VerticalLayout {
             welcomeMessage.addClassName("welcome-message");
             
             profileSection.add(profileImage, welcomeMessage);
-            
-            add(title, profileSection);
+
+            HorizontalLayout actionButtons = new HorizontalLayout();
+            actionButtons.addClassName("main-action-buttons");
+            actionButtons.setSpacing(true);
+            actionButtons.add(
+                createNavigationButton("Open posts", "/posts", ButtonVariant.LUMO_PRIMARY),
+                createNavigationButton("View stats", "/stats")
+            );
+
+            add(title, profileSection, actionButtons);
         } catch (Exception e) {
             // Fallback to simple view if there's an error
             H1 title = new H1("Welcome back!");
@@ -156,5 +164,14 @@ public class MainView extends VerticalLayout {
             return currentUser.getEmail().trim();
         }
         return "there";
+    }
+
+    private Button createNavigationButton(String text, String route, ButtonVariant... themeVariants) {
+        Button button = new Button(text, click -> getUI().ifPresent(ui -> ui.getPage().setLocation(route)));
+        button.addClassName("main-action-button");
+        if (themeVariants.length > 0) {
+            button.addThemeVariants(themeVariants);
+        }
+        return button;
     }
 }

--- a/src/main/resources/META-INF/resources/frontend/styles/main-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/main-view.css
@@ -30,6 +30,18 @@
     font-weight: 600;
 }
 
+.main-action-buttons {
+    display: flex;
+    gap: 0.75rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.main-action-button {
+    min-width: 9rem;
+    font-weight: 600;
+}
+
 /* Welcome Message Styles */
 .welcome-message {
     text-align: center;
@@ -70,4 +82,14 @@
 
 .main-profile-image:hover {
     border-color: var(--tnra-accent);
+}
+
+@media (max-width: 480px) {
+    .main-action-buttons {
+        width: 100%;
+    }
+
+    .main-action-button {
+        flex: 1 1 100%;
+    }
 }

--- a/src/test/java/com/afitnerd/tnra/service/AuthNavigationServiceTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/AuthNavigationServiceTest.java
@@ -33,4 +33,18 @@ class AuthNavigationServiceTest {
 
         assertEquals("/oauth2/authorization/okta", service.getLoginPath());
     }
+
+    @Test
+    void rejectsProtocolRelativeConfiguredPath() {
+        AuthNavigationService service = new AuthNavigationService("//evil.example/login", "oidc");
+
+        assertEquals("/oauth2/authorization/oidc", service.getLoginPath());
+    }
+
+    @Test
+    void fallsBackToOktaWhenRegistrationIdContainsUnsafeCharacters() {
+        AuthNavigationService service = new AuthNavigationService("", "../bad/id");
+
+        assertEquals("/oauth2/authorization/okta", service.getLoginPath());
+    }
 }

--- a/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
@@ -54,6 +54,21 @@ class FileStorageServiceImplTest {
     }
 
     @Test
+    void deleteFileRejectsTraversalOutsideUploadDirectory() throws IOException {
+        FileStorageServiceImpl service = new FileStorageServiceImpl();
+        Path uploadPath = tempDir.resolve("uploads");
+        ReflectionTestUtils.setField(service, "uploadDir", uploadPath.toString());
+        Files.createDirectories(uploadPath);
+
+        Path outsideFile = tempDir.resolve("outside.txt");
+        Files.writeString(outsideFile, "content");
+
+        service.deleteFile("../outside.txt");
+
+        assertTrue(Files.exists(outsideFile));
+    }
+
+    @Test
     void getFileUrlReturnsNullForBlankValuesAndPrefixesBaseUrl() {
         FileStorageServiceImpl service = new FileStorageServiceImpl();
         ReflectionTestUtils.setField(service, "baseUrl", "/files");

--- a/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
@@ -254,4 +254,24 @@ class MainViewTest {
 
         assertTrue(hasLoginButton, "Expected unauthenticated view to include a log in button");
     }
+
+    @Test
+    void testMainViewShowsQuickActionsForAuthenticatedUsers() {
+        when(oidcUserService.isAuthenticated()).thenReturn(true);
+        when(oidcUserService.getDisplayName()).thenReturn("Test User");
+        when(userService.getCurrentUser()).thenReturn(testUser);
+
+        mainView = new MainView(oidcUserService, userService, fileStorageService, authNavigationService);
+
+        boolean hasPostsButton = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .anyMatch(component -> component instanceof Button && "Open posts".equals(((Button) component).getText()));
+
+        boolean hasStatsButton = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .anyMatch(component -> component instanceof Button && "View stats".equals(((Button) component).getText()));
+
+        assertTrue(hasPostsButton, "Expected authenticated view to include Open posts quick action");
+        assertTrue(hasStatsButton, "Expected authenticated view to include View stats quick action");
+    }
 }


### PR DESCRIPTION
## Summary\n- Hardened auth login path resolution to reject protocol-relative redirects and sanitize invalid OAuth registration IDs\n- Hardened file deletion to prevent path traversal outside the configured upload directory\n- Improved authenticated  UX with quick action buttons for Posts and Stats plus responsive styling\n- Added/updated tests for all new behavior\n\n## Testing\n- ./mvnw test (260 tests, 0 failures)