### PR TITLE
Improve main view UX and harden auth/file path handling

### DIFF
--- a/src/main/java/com/afitnerd/tnra/service/AuthNavigationService.java
+++ b/src/main/java/com/afitnerd/tnra/service/AuthNavigationService.java
@@ -4,8 +4,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+import java.util.regex.Pattern;
+
 @Service
 public class AuthNavigationService {
+
+    private static final String DEFAULT_REGISTRATION_ID = "okta";
+    private static final Pattern REGISTRATION_ID_PATTERN = Pattern.compile("[A-Za-z0-9._-]+");
 
     private final String loginPath;
 
@@ -23,10 +28,37 @@ public class AuthNavigationService {
     static String resolveLoginPath(String configuredLoginPath, String registrationId) {
         if (StringUtils.hasText(configuredLoginPath)) {
             String path = configuredLoginPath.trim();
-            return path.startsWith("/") ? path : "/" + path;
+            if (isSafeRelativePath(path)) {
+                return path.startsWith("/") ? path : "/" + path;
+            }
         }
 
-        String safeRegistrationId = StringUtils.hasText(registrationId) ? registrationId.trim() : "okta";
+        String safeRegistrationId = sanitizeRegistrationId(registrationId);
         return "/oauth2/authorization/" + safeRegistrationId;
+    }
+
+    private static boolean isSafeRelativePath(String path) {
+        if (!StringUtils.hasText(path)) {
+            return false;
+        }
+        if (path.startsWith("//")) {
+            return false;
+        }
+        if (path.contains("://")) {
+            return false;
+        }
+        return !path.contains("\\");
+    }
+
+    private static String sanitizeRegistrationId(String registrationId) {
+        if (!StringUtils.hasText(registrationId)) {
+            return DEFAULT_REGISTRATION_ID;
+        }
+
+        String candidate = registrationId.trim();
+        if (!REGISTRATION_ID_PATTERN.matcher(candidate).matches()) {
+            return DEFAULT_REGISTRATION_ID;
+        }
+        return candidate;
     }
 }

--- a/src/main/java/com/afitnerd/tnra/service/FileStorageServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/FileStorageServiceImpl.java
@@ -3,6 +3,8 @@ package com.afitnerd.tnra.service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,6 +16,8 @@ import java.util.UUID;
 
 @Service
 public class FileStorageServiceImpl implements FileStorageService {
+
+    private static final Logger log = LoggerFactory.getLogger(FileStorageServiceImpl.class);
 
     @Value("${app.file-storage.upload-dir:uploads}")
     private String uploadDir;
@@ -45,14 +49,21 @@ public class FileStorageServiceImpl implements FileStorageService {
 
     @Override
     public void deleteFile(String fileName) {
-        if (fileName != null && !fileName.isEmpty()) {
-            try {
-                Path filePath = Paths.get(uploadDir, fileName);
-                Files.deleteIfExists(filePath);
-            } catch (IOException e) {
-                // Log error but don't throw - file might already be deleted
-                System.err.println("Error deleting file: " + fileName + " - " + e.getMessage());
+        if (!StringUtils.hasText(fileName)) {
+            return;
+        }
+
+        try {
+            Path uploadPath = Paths.get(uploadDir).toAbsolutePath().normalize();
+            Path filePath = uploadPath.resolve(fileName).normalize();
+            if (!filePath.startsWith(uploadPath)) {
+                log.warn("Blocked delete outside upload directory: {}", fileName);
+                return;
             }
+            Files.deleteIfExists(filePath);
+        } catch (IOException e) {
+            // Log error but don't throw - file might already be deleted
+            log.warn("Error deleting file {}: {}", fileName, e.getMessage());
         }
     }
 

--- a/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
@@ -116,8 +116,9 @@ public class MainView extends VerticalLayout {
             welcomeMessage.addClassName("welcome-message");
             
             profileSection.add(profileImage, welcomeMessage);
-            
-            add(title, profileSection);
+
+            HorizontalLayout quickActions = createAuthenticatedQuickActions();
+            add(title, profileSection, quickActions);
         } catch (Exception e) {
             // Fallback to simple view if there's an error
             H1 title = new H1("Welcome back!");
@@ -132,11 +133,39 @@ public class MainView extends VerticalLayout {
                 "Note: Could not retrieve user details due to an error."
             );
             errorMessage.addClassName("error-message");
-            
-            add(title, welcomeMessage, errorMessage);
+
+            HorizontalLayout quickActions = createAuthenticatedQuickActions();
+            add(title, welcomeMessage, errorMessage, quickActions);
 
             log.warn("Error while rendering authenticated main view", e);
         }
+    }
+
+    private HorizontalLayout createAuthenticatedQuickActions() {
+        HorizontalLayout quickActions = new HorizontalLayout();
+        quickActions.addClassName("main-quick-actions");
+        quickActions.setSpacing(true);
+
+        Button postsButton = new Button("Open Posts", event ->
+            event.getSource().getUI().ifPresent(ui -> ui.navigate("posts"))
+        );
+        postsButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        postsButton.addClassName("main-action-button");
+
+        Button statsButton = new Button("View Stats", event ->
+            event.getSource().getUI().ifPresent(ui -> ui.navigate("stats"))
+        );
+        statsButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        statsButton.addClassName("main-action-button");
+
+        Button profileButton = new Button("Edit Profile", event ->
+            event.getSource().getUI().ifPresent(ui -> ui.navigate("profile"))
+        );
+        profileButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        profileButton.addClassName("main-action-button");
+
+        quickActions.add(postsButton, statsButton, profileButton);
+        return quickActions;
     }
 
     private String resolveDisplayName(String displayName, User currentUser) {

--- a/src/main/resources/META-INF/resources/frontend/styles/main-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/main-view.css
@@ -71,3 +71,25 @@
 .main-profile-image:hover {
     border-color: var(--tnra-accent);
 }
+
+.main-quick-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.main-action-button {
+    min-width: 9rem;
+}
+
+@media (max-width: 640px) {
+    .profile-section {
+        flex-direction: column;
+        text-align: center;
+    }
+
+    .main-action-button {
+        width: 100%;
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/service/AuthNavigationServiceTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/AuthNavigationServiceTest.java
@@ -33,4 +33,25 @@ class AuthNavigationServiceTest {
 
         assertEquals("/oauth2/authorization/okta", service.getLoginPath());
     }
+
+    @Test
+    void ignoresUnsafeConfiguredPathAndFallsBackToRegistrationId() {
+        AuthNavigationService service = new AuthNavigationService("https://example.com/login", "custom");
+
+        assertEquals("/oauth2/authorization/custom", service.getLoginPath());
+    }
+
+    @Test
+    void ignoresProtocolRelativeConfiguredPathAndFallsBack() {
+        AuthNavigationService service = new AuthNavigationService("//evil.example/login", "custom");
+
+        assertEquals("/oauth2/authorization/custom", service.getLoginPath());
+    }
+
+    @Test
+    void fallsBackToDefaultWhenRegistrationIdContainsInvalidCharacters() {
+        AuthNavigationService service = new AuthNavigationService("", "../bad-id");
+
+        assertEquals("/oauth2/authorization/okta", service.getLoginPath());
+    }
 }

--- a/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
@@ -54,6 +54,21 @@ class FileStorageServiceImplTest {
     }
 
     @Test
+    void deleteFileBlocksTraversalOutsideUploadDirectory() throws IOException {
+        FileStorageServiceImpl service = new FileStorageServiceImpl();
+        Path uploadPath = tempDir.resolve("uploads");
+        Files.createDirectories(uploadPath);
+        ReflectionTestUtils.setField(service, "uploadDir", uploadPath.toString());
+
+        Path outsideFile = tempDir.resolve("outside.txt");
+        Files.writeString(outsideFile, "keep");
+
+        service.deleteFile("../outside.txt");
+
+        assertTrue(Files.exists(outsideFile));
+    }
+
+    @Test
     void getFileUrlReturnsNullForBlankValuesAndPrefixesBaseUrl() {
         FileStorageServiceImpl service = new FileStorageServiceImpl();
         ReflectionTestUtils.setField(service, "baseUrl", "/files");

--- a/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
@@ -244,6 +244,29 @@ class MainViewTest {
     }
 
     @Test
+    void testMainViewShowsQuickActionButtonsForAuthenticatedUsers() {
+        when(oidcUserService.isAuthenticated()).thenReturn(true);
+        when(oidcUserService.getDisplayName()).thenReturn("Test User");
+        when(userService.getCurrentUser()).thenReturn(testUser);
+
+        mainView = new MainView(oidcUserService, userService, fileStorageService, authNavigationService);
+
+        boolean hasPostsButton = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .anyMatch(component -> component instanceof Button && "Open Posts".equals(((Button) component).getText()));
+        boolean hasStatsButton = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .anyMatch(component -> component instanceof Button && "View Stats".equals(((Button) component).getText()));
+        boolean hasProfileButton = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .anyMatch(component -> component instanceof Button && "Edit Profile".equals(((Button) component).getText()));
+
+        assertTrue(hasPostsButton, "Expected authenticated view to include Open Posts action");
+        assertTrue(hasStatsButton, "Expected authenticated view to include View Stats action");
+        assertTrue(hasProfileButton, "Expected authenticated view to include Edit Profile action");
+    }
+
+    @Test
     void testMainViewShowsLoginButtonForUnauthenticatedUsers() {
         when(oidcUserService.isAuthenticated()).thenReturn(false);
 


### PR DESCRIPTION
## Summary
- add authenticated quick-action buttons on MainView (Posts, Stats, Profile) and responsive styling updates
- harden AuthNavigationService login path resolution to reject unsafe configured paths and sanitize registration IDs
- harden FileStorageServiceImpl.deleteFile to block traversal outside the configured upload directory
- add/extend tests for all new behavior in MainView/AuthNavigationService/FileStorageServiceImpl

## Testing
- ./mvnw test
