### PR TITLE
Fix GTG notify recipient + add Home quick link to Posts

### DIFF
--- a/src/main/java/com/afitnerd/tnra/controller/APIController.java
+++ b/src/main/java/com/afitnerd/tnra/controller/APIController.java
@@ -75,7 +75,7 @@ public class APIController {
             eMailService.sendTextViaMail(gtgPair.getCallee(), calleePost);
             // send callee what and when
             Post callerPost = postService.getLastFinishedPost(gtgPair.getCaller());
-            eMailService.sendTextViaMail(gtgPair.getCallee(), callerPost);
+            eMailService.sendTextViaMail(gtgPair.getCaller(), callerPost);
             //}
         });
         return goToGuySet;

--- a/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
@@ -114,8 +114,14 @@ public class MainView extends VerticalLayout {
                 "Hello, " + resolvedDisplayName + "! You are now logged in."
             );
             welcomeMessage.addClassName("welcome-message");
+
+            Button openPostsButton = new Button("Open Posts", click ->
+                getUI().ifPresent(ui -> ui.navigate(PostView.class))
+            );
+            openPostsButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+            openPostsButton.addClassName("main-posts-button");
             
-            profileSection.add(profileImage, welcomeMessage);
+            profileSection.add(profileImage, welcomeMessage, openPostsButton);
             
             add(title, profileSection);
         } catch (Exception e) {

--- a/src/main/resources/META-INF/resources/frontend/styles/main-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/main-view.css
@@ -30,6 +30,11 @@
     font-weight: 600;
 }
 
+.main-posts-button {
+    min-width: 9rem;
+    font-weight: 600;
+}
+
 /* Welcome Message Styles */
 .welcome-message {
     text-align: center;

--- a/src/test/java/com/afitnerd/tnra/controller/APIControllerTest.java
+++ b/src/test/java/com/afitnerd/tnra/controller/APIControllerTest.java
@@ -77,7 +77,7 @@ class APIControllerTest {
 
         assertSame(gtgSet, returned);
         verify(eMailService).sendTextViaMail(callee, calleePost);
-        verify(eMailService).sendTextViaMail(callee, callerPost);
+        verify(eMailService).sendTextViaMail(caller, callerPost);
     }
 
     @Test

--- a/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
@@ -254,4 +254,19 @@ class MainViewTest {
 
         assertTrue(hasLoginButton, "Expected unauthenticated view to include a log in button");
     }
+
+    @Test
+    void testMainViewShowsOpenPostsButtonForAuthenticatedUsers() {
+        when(oidcUserService.isAuthenticated()).thenReturn(true);
+        when(oidcUserService.getDisplayName()).thenReturn("Test User");
+        when(userService.getCurrentUser()).thenReturn(testUser);
+
+        mainView = new MainView(oidcUserService, userService, fileStorageService, authNavigationService);
+
+        boolean hasOpenPostsButton = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .anyMatch(component -> component instanceof Button && "Open Posts".equals(((Button) component).getText()));
+
+        assertTrue(hasOpenPostsButton, "Expected authenticated view to include an Open Posts button");
+    }
 }


### PR DESCRIPTION
## Summary\n- fix backend GTG notification logic so caller receives caller post content (instead of sending both notifications to callee)\n- add an authenticated-home UI shortcut button (`Open Posts`) to navigate directly to the posts experience\n- add/update tests for both behaviors and add minor styling for the new CTA\n\n## Verification\n- ./mvnw test\n  - Tests run: 257\n  - Failures: 0\n  - Errors: 0\n  - Skipped: 0