### PR TITLE
Improve stats view robustness and harden email delivery edge cases

### DIFF
--- a/src/main/java/com/afitnerd/tnra/service/EmailServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/EmailServiceImpl.java
@@ -80,12 +80,12 @@ public class EmailServiceImpl implements EMailService {
                     .addTextBody(
                         "html",
                         emailPostRenderer.render(post),
-                        ContentType.create("text/hmtl", StandardCharsets.UTF_8)
+                        ContentType.create("text/html", StandardCharsets.UTF_8)
                     )
                     .build();
 
                 InputStream responseStream = Request.post(mailgunUrl)
-                    .addHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(("api:" + mailgunPrivateKey).getBytes("utf-8")))
+                    .addHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(("api:" + mailgunPrivateKey).getBytes(StandardCharsets.UTF_8)))
                     .body(entity)
                     .execute().returnContent().asStream();
                 Map<String, Object> response =  mapper.readValue(responseStream, typeRef);
@@ -118,7 +118,7 @@ public class EmailServiceImpl implements EMailService {
                 .addTextBody("text", "\n" + text)
                 .build();
             InputStream responseStream = Request.post(mailgunUrl)
-                .addHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(("api:" + mailgunPrivateKey).getBytes("utf-8")))
+                .addHeader("Authorization", "Basic " + Base64.getEncoder().encodeToString(("api:" + mailgunPrivateKey).getBytes(StandardCharsets.UTF_8)))
                 .body(entity)
                 .execute().returnContent().asStream();
             Map<String, Object> response =  mapper.readValue(responseStream, typeRef);
@@ -129,9 +129,14 @@ public class EmailServiceImpl implements EMailService {
     }
 
     private List<String> split(String prefix, String s) {
+        if (s == null || s.isEmpty()) {
+            return List.of();
+        }
+
+        int chunkSize = Math.max(1, maxEmailToSmsLength - prefix.length());
         List<String> chunks = new ArrayList<>();
-        for (int i = 0; i < s.length(); i += (maxEmailToSmsLength-prefix.length())) {
-            chunks.add(s.substring(i, Math.min(s.length(), i + (maxEmailToSmsLength-prefix.length()))));
+        for (int i = 0; i < s.length(); i += chunkSize) {
+            chunks.add(s.substring(i, Math.min(s.length(), i + chunkSize)));
         }
         return chunks;
     }
@@ -141,6 +146,9 @@ public class EmailServiceImpl implements EMailService {
         Runnable runnableTask = () -> {
             User postUser = post.getUser();
             String waw = PostRenderer.utf8ToAscii(post.getIntro().getWhatAndWhen());
+            if (waw == null) {
+                waw = "";
+            }
             String prefix = postUser.getFirstName() + " " + postUser.getLastName() + " (%d of %d)";
             String to = user.getPhoneNumber() + "@" + user.getTextEmailSuffix();
             if ("vtext.com".equals(user.getTextEmailSuffix().toLowerCase().trim())) {

--- a/src/main/java/com/afitnerd/tnra/service/PostRenderer.java
+++ b/src/main/java/com/afitnerd/tnra/service/PostRenderer.java
@@ -14,6 +14,9 @@ public interface PostRenderer {
     String render(Post post);
 
     static String utf8ToAscii(String input) {
+        if (input == null) {
+            return null;
+        }
         return input
             .replaceAll("’", "'").replaceAll("‛", "'")
             .replaceAll("‟", "\"").replaceAll("”", "\"");

--- a/src/main/java/com/afitnerd/tnra/vaadin/StatsView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/StatsView.java
@@ -6,6 +6,7 @@ import com.afitnerd.tnra.model.User;
 import com.afitnerd.tnra.vaadin.presenter.VaadinPostPresenter;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.html.H1;
+import com.vaadin.flow.component.html.Paragraph;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
@@ -61,6 +62,8 @@ public class StatsView extends VerticalLayout implements AfterNavigationObserver
     }
 
     private void createStatsView() {
+        removeAll();
+
         // Header section
         VerticalLayout headerSection = createHeaderSection();
         
@@ -81,8 +84,13 @@ public class StatsView extends VerticalLayout implements AfterNavigationObserver
         // Title and date row
         H1 title = new H1("Daily Stats");
         title.addClassNames(LumoUtility.FontSize.XXXLARGE, LumoUtility.FontWeight.BOLD, "stats-title");
+        title.getElement().setProperty("id", "daily-stats-title");
 
-        header.add(title);
+        Paragraph hint = new Paragraph("Use +/- buttons or type values from 0 to 99.");
+        hint.addClassName("stats-hint");
+        hint.getElement().setAttribute("aria-live", "polite");
+
+        header.add(title, hint);
         return header;
     }
 

--- a/src/main/resources/META-INF/resources/frontend/styles/stats-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/stats-view.css
@@ -18,6 +18,12 @@
     font-size: 0.9rem;
 }
 
+.stats-hint {
+    margin: 0.35rem 0 0;
+    color: var(--tnra-text-secondary);
+    font-size: 0.9rem;
+}
+
 /* Stats Grid */
 .stats-grid {
     flex-wrap: wrap;

--- a/src/test/java/com/afitnerd/tnra/service/EmailServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/EmailServiceImplTest.java
@@ -1,0 +1,73 @@
+package com.afitnerd.tnra.service;
+
+import com.afitnerd.tnra.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class EmailServiceImplTest {
+
+    @Mock
+    private PostRenderer postRenderer;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private EmailServiceImpl emailService;
+    private Method splitMethod;
+
+    @BeforeEach
+    void setUp() throws NoSuchMethodException {
+        emailService = new EmailServiceImpl(postRenderer, userRepository);
+        splitMethod = EmailServiceImpl.class.getDeclaredMethod("split", String.class, String.class);
+        splitMethod.setAccessible(true);
+    }
+
+    @Test
+    void splitReturnsSingleCharacterChunksWhenPrefixConsumesMaxLength() throws Exception {
+        ReflectionTestUtils.setField(emailService, "maxEmailToSmsLength", 8);
+
+        @SuppressWarnings("unchecked")
+        List<String> chunks = (List<String>) splitMethod.invoke(emailService, "12345678", "abcd");
+
+        assertEquals(List.of("a", "b", "c", "d"), chunks);
+    }
+
+    @Test
+    void splitUsesRemainingCharacterBudgetPerChunk() throws Exception {
+        ReflectionTestUtils.setField(emailService, "maxEmailToSmsLength", 15);
+
+        @SuppressWarnings("unchecked")
+        List<String> chunks = (List<String>) splitMethod.invoke(emailService, "prefix", "abcdefghij");
+
+        assertEquals(2, chunks.size());
+        assertEquals("abcdefghi", chunks.get(0));
+        assertEquals("j", chunks.get(1));
+    }
+
+    @Test
+    void splitReturnsEmptyListForEmptyOrNullInput() throws Exception {
+        ReflectionTestUtils.setField(emailService, "maxEmailToSmsLength", 20);
+
+        @SuppressWarnings("unchecked")
+        List<String> empty = (List<String>) splitMethod.invoke(emailService, "prefix", "");
+        @SuppressWarnings("unchecked")
+        List<String> nullInput = (List<String>) splitMethod.invoke(emailService, "prefix", null);
+
+        assertNotNull(empty);
+        assertNotNull(nullInput);
+        assertTrue(empty.isEmpty());
+        assertTrue(nullInput.isEmpty());
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/service/PostRendererTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/PostRendererTest.java
@@ -1,0 +1,22 @@
+package com.afitnerd.tnra.service;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class PostRendererTest {
+
+    @Test
+    void utf8ToAsciiConvertsSmartQuotes() {
+        String input = "It’s a test with ‛single‛ and ”double‟ quotes";
+        String expected = "It's a test with 'single' and \"double\" quotes";
+
+        assertEquals(expected, PostRenderer.utf8ToAscii(input));
+    }
+
+    @Test
+    void utf8ToAsciiReturnsNullForNullInput() {
+        assertNull(PostRenderer.utf8ToAscii(null));
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/vaadin/StatsViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/StatsViewTest.java
@@ -132,6 +132,23 @@ class StatsViewTest {
     }
 
     @Test
+    void testAfterNavigationTwiceDoesNotDuplicateTopLevelComponents() {
+        lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.of(inProgressPost));
+
+        try (MockedStatic<UI> mockedUI = mockStatic(UI.class)) {
+            setupUIMocks("America/New_York");
+            mockedUI.when(UI::getCurrent).thenReturn(mockUI);
+
+            statsView = new StatsView(vaadinPostPresenter);
+            statsView.afterNavigation(mockAfterNavigationEvent());
+            assertEquals(2, statsView.getComponentCount());
+
+            statsView.afterNavigation(mockAfterNavigationEvent());
+            assertEquals(2, statsView.getComponentCount());
+        }
+    }
+
+    @Test
     void testSetPost() {
         // Arrange
         StatsView embeddedStatsView = StatsView.createEmbedded(vaadinPostPresenter);


### PR DESCRIPTION
## Summary
- prevent duplicated Stats page content by clearing and rebuilding UI on navigation
- add a concise stats input hint and accessible title id for the Stats header
- fix Mailgun HTML content type typo (`text/hmtl` -> `text/html`)
- make email/text authorization encoding use `StandardCharsets.UTF_8`
- harden SMS chunk splitting for null/empty text and small max-length configs
- make `PostRenderer.utf8ToAscii` null-safe to avoid NPEs in email/text paths

## Tests
- ./mvnw test
- added `EmailServiceImplTest` for split edge cases
- added `PostRendererTest` for smart-quote conversion and null input
- extended `StatsViewTest` to verify repeated navigation does not duplicate top-level components
