### PR TITLE
Harden post editing null paths and improve completed-posts empty state

### DIFF
--- a/src/main/java/com/afitnerd/tnra/service/PostServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/PostServiceImpl.java
@@ -88,6 +88,9 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post replaceStats(User user, Stats stats) {
         Post post = ensureOneInProgressPost(user);
+        if (post.getStats() == null) {
+            post.setStats(new Stats());
+        }
         mergeReplace(post.getStats(), stats);
         return postRepository.save(post);
     }
@@ -95,6 +98,9 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post updateCompleteStats(User user, Stats stats) {
         Post post = ensureOneInProgressPost(user);
+        if (post.getStats() == null) {
+            post.setStats(new Stats());
+        }
         mergeReplaceAllowNulls(post.getStats(), stats);
         return postRepository.save(post);
     }
@@ -102,6 +108,9 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post replaceIntro(User user, Intro intro) {
         Post post = ensureOneInProgressPost(user);
+        if (post.getIntro() == null) {
+            post.setIntro(new Intro());
+        }
         mergeReplace(post.getIntro(), intro);
         return postRepository.save(post);
     }
@@ -109,6 +118,9 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post replacePersonal(User user, Category personal) {
         Post post = ensureOneInProgressPost(user);
+        if (post.getPersonal() == null) {
+            post.setPersonal(new Category());
+        }
         mergeReplace(post.getPersonal(), personal);
         return postRepository.save(post);
     }
@@ -116,6 +128,9 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post replaceFamily(User user, Category family) {
         Post post = ensureOneInProgressPost(user);
+        if (post.getFamily() == null) {
+            post.setFamily(new Category());
+        }
         mergeReplace(post.getFamily(), family);
         return postRepository.save(post);
     }
@@ -123,6 +138,9 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post replaceWork(User user, Category work) {
         Post post = ensureOneInProgressPost(user);
+        if (post.getWork() == null) {
+            post.setWork(new Category());
+        }
         mergeReplace(post.getWork(), work);
         return postRepository.save(post);
     }
@@ -130,6 +148,9 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post updateIntro(User user, Intro intro) {
         Post post = ensureOneInProgressPost(user);
+        if (post.getIntro() == null) {
+            post.setIntro(new Intro());
+        }
         intro = mergeAppendString(post.getIntro(), intro);
         return postRepository.save(post);
     }
@@ -137,6 +158,9 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post updatePersonal(User user, Category personal) {
         Post post = ensureOneInProgressPost(user);
+        if (post.getPersonal() == null) {
+            post.setPersonal(new Category());
+        }
         personal = mergeAppendString(post.getPersonal(), personal);
         return postRepository.save(post);
     }
@@ -144,6 +168,9 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post updateFamily(User user, Category family) {
         Post post = ensureOneInProgressPost(user);
+        if (post.getFamily() == null) {
+            post.setFamily(new Category());
+        }
         family = mergeAppendString(post.getFamily(), family);
         return postRepository.save(post);
     }
@@ -151,6 +178,9 @@ public class PostServiceImpl implements PostService {
     @Override
     public Post updateWork(User user, Category work) {
         Post post = ensureOneInProgressPost(user);
+        if (post.getWork() == null) {
+            post.setWork(new Category());
+        }
         work = mergeAppendString(post.getWork(), work);
         return postRepository.save(post);
     }
@@ -170,8 +200,8 @@ public class PostServiceImpl implements PostService {
     }
 
     private <T> T mergeAppendString(T origOne, T newOne) {
-        Assert.notNull(origOne, "Orig " + origOne.getClass().getName() + " must not be null." );
-        Assert.notNull(newOne, "New " + origOne.getClass().getName() + " must not be null." );
+        Assert.notNull(origOne, "Original object must not be null.");
+        Assert.notNull(newOne, "New object must not be null.");
 
         PropertyDescriptor[] descriptors = BeanUtils.getPropertyDescriptors(origOne.getClass());
         for (PropertyDescriptor pd : descriptors) {
@@ -191,8 +221,8 @@ public class PostServiceImpl implements PostService {
     }
 
     private <T> T mergeReplace(T origOne, T newOne) {
-        Assert.notNull(origOne, "Orig " + origOne.getClass().getName() + " must not be null." );
-        Assert.notNull(newOne, "New " + origOne.getClass().getName() + " must not be null." );
+        Assert.notNull(origOne, "Original object must not be null.");
+        Assert.notNull(newOne, "New object must not be null.");
 
         PropertyDescriptor[] descriptors = BeanUtils.getPropertyDescriptors(origOne.getClass());
         for (PropertyDescriptor pd : descriptors) {
@@ -211,8 +241,8 @@ public class PostServiceImpl implements PostService {
     }
 
     private <T> T mergeReplaceAllowNulls(T origOne, T newOne) {
-        Assert.notNull(origOne, "Orig " + origOne.getClass().getName() + " must not be null." );
-        Assert.notNull(newOne, "New " + origOne.getClass().getName() + " must not be null." );
+        Assert.notNull(origOne, "Original object must not be null.");
+        Assert.notNull(newOne, "New object must not be null.");
 
         PropertyDescriptor[] descriptors = BeanUtils.getPropertyDescriptors(origOne.getClass());
         for (PropertyDescriptor pd : descriptors) {

--- a/src/main/java/com/afitnerd/tnra/vaadin/PostView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/PostView.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.Optional;
@@ -59,6 +60,7 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver 
     private ComboBox<Integer> pageSizeSelector;
     private IntegerField pageNumberField;
     private Span pageInfoLabel;
+    private Span noCompletedPostsMessage;
     
     // View mode controls
     private Button showCompletedPostsButton;
@@ -301,7 +303,12 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver 
         // Create pagination controls
         VerticalLayout paginationLayout = createPaginationControls();
 
-        completedLayout.add(selectorsLayout, paginationLayout);
+        noCompletedPostsMessage = new Span();
+        noCompletedPostsMessage.addClassName("empty-completed-posts-message");
+        noCompletedPostsMessage.setVisible(false);
+
+        completedLayout.add(selectorsLayout, paginationLayout, noCompletedPostsMessage);
+        updateCompletedPostsEmptyState();
         return completedLayout;
     }
 
@@ -469,19 +476,23 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver 
         if (currentPageData == null) return;
         
         int totalPages = currentPageData.getTotalPages();
-        
-        // Update button states
-        firstPageButton.setEnabled(currentPage > 0);
-        previousPageButton.setEnabled(currentPage > 0);
-        nextPageButton.setEnabled(currentPage < totalPages - 1);
-        lastPageButton.setEnabled(currentPage < totalPages - 1);
+        boolean hasPages = totalPages > 0;
 
-        // Update page number field
-        pageNumberField.setValue(currentPage + 1);
-        pageNumberField.setMax(totalPages);
+        // Update button states
+        firstPageButton.setEnabled(hasPages && currentPage > 0);
+        previousPageButton.setEnabled(hasPages && currentPage > 0);
+        nextPageButton.setEnabled(hasPages && currentPage < totalPages - 1);
+        lastPageButton.setEnabled(hasPages && currentPage < totalPages - 1);
+
+        // Keep page controls valid even when there are no completed posts
+        int visibleTotalPages = Math.max(totalPages, 1);
+        int visiblePage = hasPages ? currentPage + 1 : 1;
+        pageNumberField.setValue(visiblePage);
+        pageNumberField.setMax(visibleTotalPages);
 
         // Update page info label
-        pageInfoLabel.setText("of " + totalPages);
+        pageInfoLabel.setText("of " + visibleTotalPages);
+        updateCompletedPostsEmptyState();
     }
 
     private void updatePostSelector() {
@@ -491,6 +502,46 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver 
             postSelector.setItems(new ArrayList<>());
         }
         postSelector.setValue(null);
+        updateCompletedPostsEmptyState();
+    }
+
+    private void updateCompletedPostsEmptyState() {
+        if (currentPageData == null) {
+            return;
+        }
+
+        boolean hasPosts = !currentPageData.getContent().isEmpty();
+
+        if (postSelector != null) {
+            postSelector.setEnabled(hasPosts);
+        }
+        if (pageNumberField != null) {
+            pageNumberField.setEnabled(hasPosts);
+        }
+
+        if (noCompletedPostsMessage != null) {
+            if (hasPosts) {
+                noCompletedPostsMessage.setVisible(false);
+                noCompletedPostsMessage.setText("");
+            } else {
+                noCompletedPostsMessage.setText("No completed posts yet for " + getDisplayName(selectedUser) + ".");
+                noCompletedPostsMessage.setVisible(true);
+            }
+        }
+    }
+
+    private String getDisplayName(User user) {
+        if (user == null) {
+            return "this user";
+        }
+        String fullName = (user.getFirstName() + " " + user.getLastName()).trim();
+        if (StringUtils.hasText(fullName) && !"null null".equalsIgnoreCase(fullName)) {
+            return fullName;
+        }
+        if (StringUtils.hasText(user.getSlackUsername())) {
+            return user.getSlackUsername();
+        }
+        return "this user";
     }
 
     private void goToFirstPage() {

--- a/src/main/resources/META-INF/resources/frontend/styles/post-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/post-view.css
@@ -237,6 +237,12 @@
     width: 300px;
 }
 
+.empty-completed-posts-message {
+    color: var(--tnra-text-secondary);
+    font-style: italic;
+    margin-top: 0.25rem;
+}
+
 
 /* =========================================
    FOOTER — sticky action bar

--- a/src/test/java/com/afitnerd/tnra/PostServiceTests.java
+++ b/src/test/java/com/afitnerd/tnra/PostServiceTests.java
@@ -228,6 +228,40 @@ public class PostServiceTests {
     }
 
     @Test
+    public void testReplaceStats_success_whenExistingStatsIsNull() {
+        Post post = postService.startPost(user);
+        post.setStats(null);
+        postRepository.save(post);
+
+        Stats stats = new Stats();
+        stats.setExercise(4);
+
+        postService.replaceStats(user, stats);
+
+        Post updated = postService.getInProgressPost(user);
+        assertNotNull(updated.getStats());
+        assertEquals(4, (int) updated.getStats().getExercise());
+    }
+
+    @Test
+    public void testUpdatePersonal_success_whenExistingCategoryIsNull() {
+        Post post = postService.startPost(user);
+        post.setPersonal(null);
+        postRepository.save(post);
+
+        com.afitnerd.tnra.model.Category personal = new com.afitnerd.tnra.model.Category();
+        personal.setBest("Recovered best");
+        personal.setWorst("Recovered worst");
+
+        postService.updatePersonal(user, personal);
+
+        Post updated = postService.getInProgressPost(user);
+        assertNotNull(updated.getPersonal());
+        assertEquals("Recovered best", updated.getPersonal().getBest());
+        assertEquals("Recovered worst", updated.getPersonal().getWorst());
+    }
+
+    @Test
     public void testReplaceStats_fail_noInProgressPost() {
         Stats stats = new Stats();
         stats.setExercise(2);

--- a/src/test/java/com/afitnerd/tnra/vaadin/PostViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/PostViewTest.java
@@ -11,6 +11,7 @@ import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.html.Span;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.page.ExtendedClientDetails;
+import com.vaadin.flow.component.textfield.IntegerField;
 import com.vaadin.flow.server.VaadinSession;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -381,6 +383,32 @@ class PostViewTest {
     }
 
     @Test
+    void testNoCompletedPostsShowsEmptyStateAndDisablesPostControls() {
+        // Arrange
+        completedPostsPage = new PageImpl<>(List.of());
+        lenient().when(vaadinPostPresenter.getCompletedPostsPage(eq(testUser), any(Pageable.class))).thenReturn(completedPostsPage);
+        lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.empty());
+
+        try (MockedStatic<UI> mockedUI = mockStatic(UI.class)) {
+            setupUIMocks("America/New_York");
+            mockedUI.when(UI::getCurrent).thenReturn(mockUI);
+
+            postView = new PostView(vaadinPostPresenter);
+            postView.afterNavigation(mockAfterNavigationEvent());
+
+            ComboBox<Post> postSelector = findComponentByClassName(postView, ComboBox.class, "post-selector");
+            IntegerField pageField = findComponentByClassName(postView, IntegerField.class, "pagination-input");
+            Span emptyState = findComponentWithText(postView, Span.class, "No completed posts yet");
+
+            assertNotNull(postSelector, "Post selector should exist");
+            assertFalse(postSelector.isEnabled(), "Post selector should be disabled when there are no posts");
+            assertNotNull(pageField, "Page number field should exist");
+            assertFalse(pageField.isEnabled(), "Page number field should be disabled when there are no posts");
+            assertNotNull(emptyState, "Empty state message should be shown for no completed posts");
+        }
+    }
+
+    @Test
     void testFormFieldsExist() {
         // Arrange
         lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.of(inProgressPost));
@@ -514,6 +542,21 @@ class PostViewTest {
 
         for (Component child : parent.getChildren().toArray(Component[]::new)) {
             T result = findComponentOfType(child, componentType);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Component> T findComponentByClassName(Component parent, Class<T> componentType, String className) {
+        if (componentType.isInstance(parent) && parent.getClassNames().contains(className)) {
+            return (T) parent;
+        }
+
+        for (Component child : parent.getChildren().toArray(Component[]::new)) {
+            T result = findComponentByClassName(child, componentType, className);
             if (result != null) {
                 return result;
             }


### PR DESCRIPTION
## Summary
- harden PostServiceImpl update/replace flows to initialize missing nested post sections (stats/intro/personal/family/work) before merge logic
- fix merge helper assertions so null guards do not dereference null values while building error messages
- improve PostView completed-posts UX when no finished posts exist by disabling post-specific controls and showing an explicit empty-state message
- style the empty-state message in post-view.css
- add regression tests in PostServiceTests and PostViewTest for the new backend and UI behavior

## Validation
- ./mvnw -q -Dtest=PostServiceTests,PostViewTest test
- ./mvnw test (291 tests, 0 failures)
