### PR TITLE
Improve empty completed-post UX and file-delete safety

### DIFF
--- a/src/main/java/com/afitnerd/tnra/service/FileStorageServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/FileStorageServiceImpl.java
@@ -3,6 +3,8 @@ package com.afitnerd.tnra.service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,6 +17,8 @@ import java.util.UUID;
 @Service
 public class FileStorageServiceImpl implements FileStorageService {
 
+    private static final Logger log = LoggerFactory.getLogger(FileStorageServiceImpl.class);
+
     @Value("${app.file-storage.upload-dir:uploads}")
     private String uploadDir;
 
@@ -24,7 +28,7 @@ public class FileStorageServiceImpl implements FileStorageService {
     @Override
     public String storeFile(InputStream inputStream, String fileName, String contentType) throws IOException {
         // Create upload directory if it doesn't exist
-        Path uploadPath = Paths.get(uploadDir);
+        Path uploadPath = Paths.get(uploadDir).toAbsolutePath().normalize();
         if (!Files.exists(uploadPath)) {
             Files.createDirectories(uploadPath);
         }
@@ -47,11 +51,16 @@ public class FileStorageServiceImpl implements FileStorageService {
     public void deleteFile(String fileName) {
         if (fileName != null && !fileName.isEmpty()) {
             try {
-                Path filePath = Paths.get(uploadDir, fileName);
+                Path uploadPath = Paths.get(uploadDir).toAbsolutePath().normalize();
+                Path filePath = uploadPath.resolve(fileName).normalize();
+                if (!filePath.startsWith(uploadPath)) {
+                    log.warn("Rejected delete for file outside upload directory: {}", fileName);
+                    return;
+                }
                 Files.deleteIfExists(filePath);
             } catch (IOException e) {
                 // Log error but don't throw - file might already be deleted
-                System.err.println("Error deleting file: " + fileName + " - " + e.getMessage());
+                log.warn("Error deleting file: {}", fileName, e);
             }
         }
     }

--- a/src/main/java/com/afitnerd/tnra/vaadin/PostView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/PostView.java
@@ -48,6 +48,7 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver 
     // UI Components
     private ComboBox<User> userSelector;
     private ComboBox<Post> postSelector;
+    private Span noCompletedPostsLabel;
     private Button startNewPostButton;
     private StatsView statsView;
     
@@ -298,10 +299,14 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver 
         // Add selectors to horizontal layout
         selectorsLayout.add(userSelector, postSelector);
 
+        noCompletedPostsLabel = new Span("No completed posts found for this user.");
+        noCompletedPostsLabel.addClassName("empty-posts-message");
+
         // Create pagination controls
         VerticalLayout paginationLayout = createPaginationControls();
 
-        completedLayout.add(selectorsLayout, paginationLayout);
+        completedLayout.add(selectorsLayout, noCompletedPostsLabel, paginationLayout);
+        updateCompletedPostsEmptyState();
         return completedLayout;
     }
 
@@ -369,6 +374,7 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver 
         if (showingCompletedPosts) {
             updatePaginationControls();
             updatePostSelector();
+            updateCompletedPostsEmptyState();
             if (postSelector != null) {
                 postSelector.setValue(null);
             }
@@ -467,30 +473,49 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver 
 
     private void updatePaginationControls() {
         if (currentPageData == null) return;
-        
+
         int totalPages = currentPageData.getTotalPages();
-        
+        int pageValue = totalPages == 0 ? 1 : currentPage + 1;
+        int pageLimit = totalPages == 0 ? 1 : totalPages;
+        boolean canGoBack = totalPages > 0 && currentPage > 0;
+        boolean canGoForward = totalPages > 0 && currentPage < totalPages - 1;
+
         // Update button states
-        firstPageButton.setEnabled(currentPage > 0);
-        previousPageButton.setEnabled(currentPage > 0);
-        nextPageButton.setEnabled(currentPage < totalPages - 1);
-        lastPageButton.setEnabled(currentPage < totalPages - 1);
+        firstPageButton.setEnabled(canGoBack);
+        previousPageButton.setEnabled(canGoBack);
+        nextPageButton.setEnabled(canGoForward);
+        lastPageButton.setEnabled(canGoForward);
 
         // Update page number field
-        pageNumberField.setValue(currentPage + 1);
-        pageNumberField.setMax(totalPages);
+        pageNumberField.setValue(pageValue);
+        pageNumberField.setMax(pageLimit);
+        pageNumberField.setEnabled(totalPages > 0);
 
         // Update page info label
         pageInfoLabel.setText("of " + totalPages);
     }
 
     private void updatePostSelector() {
+        if (postSelector == null) {
+            return;
+        }
+
         if (currentPageData != null) {
             postSelector.setItems(currentPageData.getContent());
         } else {
             postSelector.setItems(new ArrayList<>());
         }
         postSelector.setValue(null);
+        updateCompletedPostsEmptyState();
+    }
+
+    private void updateCompletedPostsEmptyState() {
+        if (postSelector == null || noCompletedPostsLabel == null) {
+            return;
+        }
+        boolean hasItems = currentPageData != null && !currentPageData.getContent().isEmpty();
+        postSelector.setEnabled(hasItems);
+        noCompletedPostsLabel.setVisible(!hasItems);
     }
 
     private void goToFirstPage() {

--- a/src/main/resources/META-INF/resources/frontend/styles/post-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/post-view.css
@@ -224,6 +224,11 @@
     margin-bottom: 0.25rem;
 }
 
+.empty-posts-message {
+    color: var(--tnra-text-secondary);
+    font-size: 0.9rem;
+}
+
 .selectors-layout {
     gap: 1rem;
     align-items: baseline;

--- a/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
@@ -54,6 +54,21 @@ class FileStorageServiceImplTest {
     }
 
     @Test
+    void deleteFileRejectsPathTraversalOutsideUploadDirectory() throws IOException {
+        FileStorageServiceImpl service = new FileStorageServiceImpl();
+        Path uploadPath = tempDir.resolve("uploads");
+        Path outsideFile = tempDir.resolve("outside.txt");
+        ReflectionTestUtils.setField(service, "uploadDir", uploadPath.toString());
+
+        Files.createDirectories(uploadPath);
+        Files.writeString(outsideFile, "should-stay");
+
+        service.deleteFile("../outside.txt");
+
+        assertTrue(Files.exists(outsideFile));
+    }
+
+    @Test
     void getFileUrlReturnsNullForBlankValuesAndPrefixesBaseUrl() {
         FileStorageServiceImpl service = new FileStorageServiceImpl();
         ReflectionTestUtils.setField(service, "baseUrl", "/files");

--- a/src/test/java/com/afitnerd/tnra/vaadin/PostViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/PostViewTest.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -361,6 +362,29 @@ class PostViewTest {
     }
 
     @Test
+    void testCompletedViewShowsEmptyStateWhenNoPostsExist() {
+        // Arrange
+        lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.empty());
+        lenient().when(vaadinPostPresenter.getCompletedPostsPage(eq(testUser), any(Pageable.class)))
+            .thenReturn(new PageImpl<>(List.of()));
+
+        try (MockedStatic<UI> mockedUI = mockStatic(UI.class)) {
+            setupUIMocks("America/New_York");
+            mockedUI.when(UI::getCurrent).thenReturn(mockUI);
+
+            postView = new PostView(vaadinPostPresenter);
+            postView.afterNavigation(mockAfterNavigationEvent());
+
+            Span emptyState = findComponentWithText(postView, Span.class, "No completed posts found");
+            assertNotNull(emptyState, "Should render an empty-state message");
+
+            ComboBox<Post> postsSelector = findComponentByClassName(postView, ComboBox.class, "post-selector");
+            assertNotNull(postsSelector, "Post selector should be present");
+            assertFalse(postsSelector.isEnabled(), "Post selector should be disabled when there are no posts");
+        }
+    }
+
+    @Test
     void testPostSelectorWithPosts() {
         // Arrange
         lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.empty());
@@ -554,6 +578,20 @@ class PostViewTest {
             }
         }
         return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Component> T findComponentByClassName(Component parent, Class<T> componentType, String className) {
+        if (componentType.isInstance(parent) && parent.getClassNames().contains(className)) {
+            return (T) parent;
+        }
+        for (Component child : parent.getChildren().toArray(Component[]::new)) {
+            T result = findComponentByClassName(child, componentType, className);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
     }
 
     private void invokeMethod(Object target, String methodName) {


### PR DESCRIPTION
## Summary
- improve PostView completed-posts mode when the selected user has no completed posts
- disable post selection and pagination input interaction for empty pages, and surface an explicit empty-state message
- harden FileStorageServiceImpl.deleteFile against path traversal and switch delete errors to structured logging
- add tests covering the empty completed-posts state and delete path traversal rejection

## Testing
- ./mvnw test