### PR TITLE
Improve MainView UX and harden file storage safety

### DIFF
--- a/src/main/java/com/afitnerd/tnra/service/FileStorageServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/FileStorageServiceImpl.java
@@ -3,6 +3,8 @@ package com.afitnerd.tnra.service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,10 +12,16 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.Locale;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Service
 public class FileStorageServiceImpl implements FileStorageService {
+
+    private static final Logger log = LoggerFactory.getLogger(FileStorageServiceImpl.class);
+    private static final Pattern SAFE_FILE_NAME_PATTERN = Pattern.compile("^[A-Za-z0-9][A-Za-z0-9._-]{0,255}$");
+    private static final Pattern SAFE_EXTENSION_PATTERN = Pattern.compile("^[A-Za-z0-9]{1,10}$");
 
     @Value("${app.file-storage.upload-dir:uploads}")
     private String uploadDir;
@@ -32,8 +40,8 @@ public class FileStorageServiceImpl implements FileStorageService {
         // Generate unique filename to prevent conflicts
         String fileExtension = StringUtils.getFilenameExtension(fileName);
         String uniqueFileName = UUID.randomUUID().toString();
-        if (fileExtension != null) {
-            uniqueFileName += "." + fileExtension;
+        if (StringUtils.hasText(fileExtension) && SAFE_EXTENSION_PATTERN.matcher(fileExtension).matches()) {
+            uniqueFileName += "." + fileExtension.toLowerCase(Locale.ROOT);
         }
 
         // Store the file
@@ -45,22 +53,47 @@ public class FileStorageServiceImpl implements FileStorageService {
 
     @Override
     public void deleteFile(String fileName) {
-        if (fileName != null && !fileName.isEmpty()) {
-            try {
-                Path filePath = Paths.get(uploadDir, fileName);
-                Files.deleteIfExists(filePath);
-            } catch (IOException e) {
-                // Log error but don't throw - file might already be deleted
-                System.err.println("Error deleting file: " + fileName + " - " + e.getMessage());
+        String safeFileName = toSafeFileName(fileName);
+        if (safeFileName == null) {
+            return;
+        }
+
+        try {
+            Path uploadPath = Paths.get(uploadDir).toAbsolutePath().normalize();
+            Path filePath = uploadPath.resolve(safeFileName).normalize();
+            if (!filePath.startsWith(uploadPath)) {
+                return;
             }
+            Files.deleteIfExists(filePath);
+        } catch (IOException e) {
+            // Log error but don't throw - file might already be deleted
+            log.warn("Error deleting file {}: {}", safeFileName, e.getMessage());
         }
     }
 
     @Override
     public String getFileUrl(String fileName) {
-        if (fileName == null || fileName.isEmpty()) {
+        String safeFileName = toSafeFileName(fileName);
+        if (safeFileName == null) {
             return null;
         }
-        return baseUrl + "/" + fileName;
+        String normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        return normalizedBaseUrl + "/" + safeFileName;
     }
-} 
+
+    private String toSafeFileName(String fileName) {
+        if (!StringUtils.hasText(fileName)) {
+            return null;
+        }
+
+        String candidate = fileName.trim();
+        String leafName = Paths.get(candidate).getFileName().toString();
+        if (!candidate.equals(leafName)) {
+            return null;
+        }
+        if (!SAFE_FILE_NAME_PATTERN.matcher(leafName).matches()) {
+            return null;
+        }
+        return leafName;
+    }
+}

--- a/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
@@ -114,10 +114,25 @@ public class MainView extends VerticalLayout {
                 "Hello, " + resolvedDisplayName + "! You are now logged in."
             );
             welcomeMessage.addClassName("welcome-message");
-            
+
+            HorizontalLayout quickActions = new HorizontalLayout();
+            quickActions.addClassName("main-quick-actions");
+            quickActions.setSpacing(true);
+
+            Button postsButton = new Button("Go to Posts", click ->
+                getUI().ifPresent(ui -> ui.navigate("posts"))
+            );
+            postsButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+            Button profileButton = new Button("View Profile", click ->
+                getUI().ifPresent(ui -> ui.navigate("profile"))
+            );
+            profileButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+
+            quickActions.add(postsButton, profileButton);
             profileSection.add(profileImage, welcomeMessage);
-            
-            add(title, profileSection);
+
+            add(title, profileSection, quickActions);
         } catch (Exception e) {
             // Fallback to simple view if there's an error
             H1 title = new H1("Welcome back!");

--- a/src/main/resources/META-INF/resources/frontend/styles/main-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/main-view.css
@@ -71,3 +71,26 @@
 .main-profile-image:hover {
     border-color: var(--tnra-accent);
 }
+
+.main-quick-actions {
+    margin-top: 0.5rem;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+@media (max-width: 640px) {
+    .profile-section {
+        flex-direction: column;
+        text-align: center;
+        padding: 1rem;
+        width: min(100%, 22rem);
+    }
+
+    .main-quick-actions {
+        width: 100%;
+    }
+
+    .main-quick-actions vaadin-button {
+        flex: 1 1 10rem;
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -56,10 +57,49 @@ class FileStorageServiceImplTest {
     @Test
     void getFileUrlReturnsNullForBlankValuesAndPrefixesBaseUrl() {
         FileStorageServiceImpl service = new FileStorageServiceImpl();
-        ReflectionTestUtils.setField(service, "baseUrl", "/files");
+        ReflectionTestUtils.setField(service, "baseUrl", "/files/");
 
         assertNull(service.getFileUrl(null));
         assertNull(service.getFileUrl(""));
         assertEquals("/files/image.webp", service.getFileUrl("image.webp"));
+    }
+
+    @Test
+    void deleteFileRejectsUnsafePathTraversalInput() throws IOException {
+        FileStorageServiceImpl service = new FileStorageServiceImpl();
+        ReflectionTestUtils.setField(service, "uploadDir", tempDir.toString());
+
+        Path outsideFile = tempDir.getParent().resolve("outside.txt");
+        Files.writeString(outsideFile, "keep");
+
+        service.deleteFile("../outside.txt");
+
+        assertTrue(Files.exists(outsideFile));
+    }
+
+    @Test
+    void getFileUrlReturnsNullForUnsafeFileNames() {
+        FileStorageServiceImpl service = new FileStorageServiceImpl();
+        ReflectionTestUtils.setField(service, "baseUrl", "/files");
+
+        assertNull(service.getFileUrl("../image.png"));
+        assertNull(service.getFileUrl("nested/image.png"));
+        assertNull(service.getFileUrl("image name.png"));
+    }
+
+    @Test
+    void storeFileDropsUnsafeExtensionCharacters() throws IOException {
+        FileStorageServiceImpl service = new FileStorageServiceImpl();
+        ReflectionTestUtils.setField(service, "uploadDir", tempDir.resolve("uploads").toString());
+
+        String fileName = service.storeFile(
+            new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)),
+            "avatar.jp*g",
+            "image/jpeg"
+        );
+
+        assertNotNull(fileName);
+        assertEquals(-1, fileName.lastIndexOf('.'));
+        assertTrue(Files.exists(Paths.get(tempDir.resolve("uploads").toString(), fileName)));
     }
 }

--- a/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
@@ -92,6 +92,24 @@ class MainViewTest {
     }
 
     @Test
+    void testAuthenticatedViewShowsQuickActionButtons() {
+        when(oidcUserService.isAuthenticated()).thenReturn(true);
+        when(oidcUserService.getDisplayName()).thenReturn("Test User");
+        when(userService.getCurrentUser()).thenReturn(testUser);
+
+        mainView = new MainView(oidcUserService, userService, fileStorageService, authNavigationService);
+
+        long quickActionCount = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .filter(component -> component instanceof Button)
+            .map(component -> (Button) component)
+            .filter(button -> "Go to Posts".equals(button.getText()) || "View Profile".equals(button.getText()))
+            .count();
+
+        assertEquals(2, quickActionCount, "Expected authenticated users to see quick action buttons");
+    }
+
+    @Test
     void testMainViewLayoutProperties() {
         // Arrange
         lenient().when(oidcUserService.isAuthenticated()).thenReturn(true);


### PR DESCRIPTION
## Summary
- add authenticated-home quick action buttons for `posts` and `profile`
- add responsive styling for profile card and action buttons on mobile widths
- harden `FileStorageServiceImpl` against unsafe filenames/path traversal and normalize URL generation
- replace stderr deletion logging with structured logger warnings
- extend tests for new MainView actions and file-storage safety/extension handling

## Testing
- ./mvnw test
