### PR TITLE
Improve main view UX and fix GTG notification routing

### DIFF
--- a/src/main/java/com/afitnerd/tnra/controller/APIController.java
+++ b/src/main/java/com/afitnerd/tnra/controller/APIController.java
@@ -11,6 +11,8 @@ import com.afitnerd.tnra.service.PostService;
 import com.afitnerd.tnra.service.SlackPostRenderer;
 import com.afitnerd.tnra.slack.service.SlackAPIService;
 import com.fasterxml.jackson.annotation.JsonView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,6 +27,7 @@ import java.util.Optional;
 @RestController
 @RequestMapping("/api/v1")
 public class APIController {
+    private static final Logger log = LoggerFactory.getLogger(APIController.class);
 
     private final PostService postService;
     private final EMailService eMailService;
@@ -68,14 +71,30 @@ public class APIController {
     @GetMapping("/notify_what_and_whens")
     public GoToGuySet notifyWhatAndWhens() {
         GoToGuySet goToGuySet = gtgLatest();
+        if (goToGuySet == null || goToGuySet.getGoToGuyPairs() == null) {
+            log.warn("Skipping notifications because there is no GTG set or GTG pair list");
+            return goToGuySet;
+        }
         goToGuySet.getGoToGuyPairs().forEach(gtgPair -> {
+            if (gtgPair.getCaller() == null || gtgPair.getCallee() == null) {
+                log.warn("Skipping GTG pair with missing caller/callee: {}", gtgPair);
+                return;
+            }
             //if (gtgPair.getCallee().getFirstName().equalsIgnoreCase("micah")) {
             // send caller what and when
             Post calleePost = postService.getLastFinishedPost(gtgPair.getCallee());
-            eMailService.sendTextViaMail(gtgPair.getCallee(), calleePost);
+            if (calleePost != null) {
+                eMailService.sendTextViaMail(gtgPair.getCaller(), calleePost);
+            } else {
+                log.warn("No finished post for callee {}. Skipping caller notification.", gtgPair.getCallee().getEmail());
+            }
             // send callee what and when
             Post callerPost = postService.getLastFinishedPost(gtgPair.getCaller());
-            eMailService.sendTextViaMail(gtgPair.getCallee(), callerPost);
+            if (callerPost != null) {
+                eMailService.sendTextViaMail(gtgPair.getCallee(), callerPost);
+            } else {
+                log.warn("No finished post for caller {}. Skipping callee notification.", gtgPair.getCaller().getEmail());
+            }
             //}
         });
         return goToGuySet;

--- a/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
@@ -114,10 +114,12 @@ public class MainView extends VerticalLayout {
                 "Hello, " + resolvedDisplayName + "! You are now logged in."
             );
             welcomeMessage.addClassName("welcome-message");
-            
+
+            HorizontalLayout quickActions = createQuickActions();
+
             profileSection.add(profileImage, welcomeMessage);
-            
-            add(title, profileSection);
+
+            add(title, profileSection, quickActions);
         } catch (Exception e) {
             // Fallback to simple view if there's an error
             H1 title = new H1("Welcome back!");
@@ -137,6 +139,28 @@ public class MainView extends VerticalLayout {
 
             log.warn("Error while rendering authenticated main view", e);
         }
+    }
+
+    private HorizontalLayout createQuickActions() {
+        HorizontalLayout quickActions = new HorizontalLayout();
+        quickActions.setSpacing(true);
+        quickActions.setAlignItems(Alignment.CENTER);
+        quickActions.addClassName("main-quick-actions");
+
+        Button postsButton = new Button("Go to Posts");
+        postsButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        postsButton.addClickListener(click -> getUI().ifPresent(ui -> ui.navigate(PostView.class)));
+
+        Button profileButton = new Button("View Profile");
+        profileButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        profileButton.addClickListener(click -> getUI().ifPresent(ui -> ui.navigate(ProfileView.class)));
+
+        Button statsButton = new Button("Edit Stats");
+        statsButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        statsButton.addClickListener(click -> getUI().ifPresent(ui -> ui.navigate(StatsView.class)));
+
+        quickActions.add(postsButton, profileButton, statsButton);
+        return quickActions;
     }
 
     private String resolveDisplayName(String displayName, User currentUser) {

--- a/src/main/resources/META-INF/resources/frontend/styles/main-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/main-view.css
@@ -71,3 +71,18 @@
 .main-profile-image:hover {
     border-color: var(--tnra-accent);
 }
+
+.main-quick-actions {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+@media (max-width: 700px) {
+    .profile-section {
+        flex-direction: column;
+        text-align: center;
+        width: min(100%, 30rem);
+        padding: 1rem;
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/controller/APIControllerTest.java
+++ b/src/test/java/com/afitnerd/tnra/controller/APIControllerTest.java
@@ -21,8 +21,10 @@ import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -76,8 +78,30 @@ class APIControllerTest {
         GoToGuySet returned = controller.notifyWhatAndWhens();
 
         assertSame(gtgSet, returned);
-        verify(eMailService).sendTextViaMail(callee, calleePost);
+        verify(eMailService).sendTextViaMail(caller, calleePost);
         verify(eMailService).sendTextViaMail(callee, callerPost);
+    }
+
+    @Test
+    void notifyWhatAndWhensSkipsNullPostsAndReturnsWhenNoSet() {
+        APIController controller = controller();
+        User caller = new User("Caller", "One", "caller@example.com");
+        User callee = new User("Callee", "Two", "callee@example.com");
+        GoToGuyPair pair = new GoToGuyPair();
+        pair.setCaller(caller);
+        pair.setCallee(callee);
+        GoToGuySet gtgSet = new GoToGuySet();
+        gtgSet.setGoToGuyPairs(List.of(pair));
+
+        when(goToGuySetRepository.findTopByOrderByStartDateDesc()).thenReturn(gtgSet);
+        when(postService.getLastFinishedPost(callee)).thenReturn(null);
+        when(postService.getLastFinishedPost(caller)).thenReturn(null);
+
+        assertSame(gtgSet, controller.notifyWhatAndWhens());
+        verify(eMailService, never()).sendTextViaMail(any(User.class), any(Post.class));
+
+        when(goToGuySetRepository.findTopByOrderByStartDateDesc()).thenReturn(null);
+        assertNull(controller.notifyWhatAndWhens());
     }
 
     @Test

--- a/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
@@ -7,7 +7,6 @@ import com.afitnerd.tnra.service.OidcUserService;
 import com.afitnerd.tnra.service.UserService;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.html.H1;
-import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Image;
 import com.vaadin.flow.component.html.Paragraph;
 import org.junit.jupiter.api.BeforeEach;
@@ -253,5 +252,24 @@ class MainViewTest {
             .anyMatch(component -> component instanceof Button && "Log in".equals(((Button) component).getText()));
 
         assertTrue(hasLoginButton, "Expected unauthenticated view to include a log in button");
+    }
+
+    @Test
+    void testAuthenticatedViewShowsQuickActionButtons() {
+        when(oidcUserService.isAuthenticated()).thenReturn(true);
+        when(oidcUserService.getDisplayName()).thenReturn("Test User");
+        when(userService.getCurrentUser()).thenReturn(testUser);
+
+        mainView = new MainView(oidcUserService, userService, fileStorageService, authNavigationService);
+
+        long quickActionCount = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .filter(component -> component instanceof Button)
+            .map(component -> (Button) component)
+            .map(Button::getText)
+            .filter(text -> "Go to Posts".equals(text) || "View Profile".equals(text) || "Edit Stats".equals(text))
+            .count();
+
+        assertEquals(3, quickActionCount, "Expected authenticated main view to show all quick action buttons");
     }
 }


### PR DESCRIPTION
## Summary
- fix `notifyWhatAndWhens` so each user receives their partner's finished post (caller/callee routing bug fix)
- add defensive handling/logging when GTG sets, pairs, or finished posts are missing
- improve authenticated `MainView` with quick action buttons for Posts, Profile, and Stats
- add responsive main view styling for authenticated profile panel/quick actions on smaller screens

## Testing
- ./mvnw test
