### PR TITLE
Improve home UI actions and harden upload content-type detection

### DIFF
--- a/src/main/java/com/afitnerd/tnra/controller/FileController.java
+++ b/src/main/java/com/afitnerd/tnra/controller/FileController.java
@@ -50,7 +50,11 @@ public class FileController {
     }
 
     private String determineContentType(String fileName) {
-        String extension = fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase();
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot < 0 || lastDot == fileName.length() - 1) {
+            return "application/octet-stream";
+        }
+        String extension = fileName.substring(lastDot + 1).toLowerCase();
         return switch (extension) {
             case "jpg", "jpeg" -> "image/jpeg";
             case "png" -> "image/png";

--- a/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
@@ -114,10 +114,18 @@ public class MainView extends VerticalLayout {
                 "Hello, " + resolvedDisplayName + "! You are now logged in."
             );
             welcomeMessage.addClassName("welcome-message");
+
+            HorizontalLayout actionRow = new HorizontalLayout();
+            actionRow.addClassName("main-action-row");
+            actionRow.setSpacing(true);
+
+            Button continuePostButton = buildNavigationButton("Continue your post", "posts", true);
+            Button profileButton = buildNavigationButton("Edit profile", "profile", false);
+            actionRow.add(continuePostButton, profileButton);
             
             profileSection.add(profileImage, welcomeMessage);
             
-            add(title, profileSection);
+            add(title, profileSection, actionRow);
         } catch (Exception e) {
             // Fallback to simple view if there's an error
             H1 title = new H1("Welcome back!");
@@ -156,5 +164,16 @@ public class MainView extends VerticalLayout {
             return currentUser.getEmail().trim();
         }
         return "there";
+    }
+
+    private Button buildNavigationButton(String label, String route, boolean primary) {
+        Button button = new Button(label, click -> getUI().ifPresent(ui -> ui.navigate(route)));
+        button.addClassName("main-action-button");
+        if (primary) {
+            button.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        } else {
+            button.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+        }
+        return button;
     }
 }

--- a/src/main/resources/META-INF/resources/frontend/styles/main-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/main-view.css
@@ -30,6 +30,18 @@
     font-weight: 600;
 }
 
+.main-action-row {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.main-action-button {
+    min-width: 11rem;
+    font-weight: 600;
+}
+
 /* Welcome Message Styles */
 .welcome-message {
     text-align: center;
@@ -70,4 +82,11 @@
 
 .main-profile-image:hover {
     border-color: var(--tnra-accent);
+}
+
+@media (max-width: 640px) {
+    .profile-section {
+        flex-direction: column;
+        text-align: center;
+    }
 }

--- a/src/test/java/com/afitnerd/tnra/controller/FileControllerTest.java
+++ b/src/test/java/com/afitnerd/tnra/controller/FileControllerTest.java
@@ -65,4 +65,16 @@ class FileControllerTest {
 
         assertEquals(MediaType.APPLICATION_OCTET_STREAM, response.getHeaders().getContentType());
     }
+
+    @Test
+    void serveFileFallsBackToOctetStreamWhenNoExtension() throws IOException {
+        FileController controller = new FileController();
+        ReflectionTestUtils.setField(controller, "uploadDir", tempDir.toString());
+        Files.writeString(tempDir.resolve("avatar"), "data");
+
+        ResponseEntity<Resource> response = controller.serveFile("avatar");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(MediaType.APPLICATION_OCTET_STREAM, response.getHeaders().getContentType());
+    }
 }

--- a/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
@@ -254,4 +254,23 @@ class MainViewTest {
 
         assertTrue(hasLoginButton, "Expected unauthenticated view to include a log in button");
     }
+
+    @Test
+    void testMainViewShowsActionButtonsForAuthenticatedUsers() {
+        when(oidcUserService.isAuthenticated()).thenReturn(true);
+        when(oidcUserService.getDisplayName()).thenReturn("Test User");
+        when(userService.getCurrentUser()).thenReturn(testUser);
+
+        mainView = new MainView(oidcUserService, userService, fileStorageService, authNavigationService);
+
+        boolean hasContinuePostButton = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .anyMatch(component -> component instanceof Button && "Continue your post".equals(((Button) component).getText()));
+        boolean hasProfileButton = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .anyMatch(component -> component instanceof Button && "Edit profile".equals(((Button) component).getText()));
+
+        assertTrue(hasContinuePostButton, "Expected authenticated view to include continue post button");
+        assertTrue(hasProfileButton, "Expected authenticated view to include edit profile button");
+    }
 }


### PR DESCRIPTION
## Summary
- add authenticated quick-action buttons on the main view for `posts` and `profile`
- add responsive styling for profile/action layout on smaller screens
- harden `FileController` content-type detection to safely handle filenames without an extension
- add tests covering new UI buttons and extensionless upload responses

## Testing
- ./mvnw test
