### PR TITLE
Harden file deletion and improve empty completed-post UX

### DIFF
--- a/src/main/java/com/afitnerd/tnra/service/FileStorageServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/FileStorageServiceImpl.java
@@ -3,6 +3,8 @@ package com.afitnerd.tnra.service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,6 +16,8 @@ import java.util.UUID;
 
 @Service
 public class FileStorageServiceImpl implements FileStorageService {
+
+    private static final Logger log = LoggerFactory.getLogger(FileStorageServiceImpl.class);
 
     @Value("${app.file-storage.upload-dir:uploads}")
     private String uploadDir;
@@ -47,11 +51,16 @@ public class FileStorageServiceImpl implements FileStorageService {
     public void deleteFile(String fileName) {
         if (fileName != null && !fileName.isEmpty()) {
             try {
-                Path filePath = Paths.get(uploadDir, fileName);
+                Path uploadPath = Paths.get(uploadDir).toAbsolutePath().normalize();
+                Path filePath = uploadPath.resolve(fileName).normalize();
+                if (!filePath.startsWith(uploadPath)) {
+                    log.warn("Blocked attempt to delete file outside upload directory: {}", fileName);
+                    return;
+                }
                 Files.deleteIfExists(filePath);
             } catch (IOException e) {
                 // Log error but don't throw - file might already be deleted
-                System.err.println("Error deleting file: " + fileName + " - " + e.getMessage());
+                log.warn("Error deleting file {}: {}", fileName, e.getMessage());
             }
         }
     }

--- a/src/main/java/com/afitnerd/tnra/vaadin/PostView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/PostView.java
@@ -302,6 +302,7 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver 
         VerticalLayout paginationLayout = createPaginationControls();
 
         completedLayout.add(selectorsLayout, paginationLayout);
+        updatePostSelector();
         return completedLayout;
     }
 
@@ -467,17 +468,19 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver 
 
     private void updatePaginationControls() {
         if (currentPageData == null) return;
-        
-        int totalPages = currentPageData.getTotalPages();
+
+        int totalPages = Math.max(currentPageData.getTotalPages(), 1);
+        boolean hasContent = currentPageData.hasContent();
         
         // Update button states
-        firstPageButton.setEnabled(currentPage > 0);
-        previousPageButton.setEnabled(currentPage > 0);
-        nextPageButton.setEnabled(currentPage < totalPages - 1);
-        lastPageButton.setEnabled(currentPage < totalPages - 1);
+        firstPageButton.setEnabled(hasContent && currentPage > 0);
+        previousPageButton.setEnabled(hasContent && currentPage > 0);
+        nextPageButton.setEnabled(hasContent && currentPage < totalPages - 1);
+        lastPageButton.setEnabled(hasContent && currentPage < totalPages - 1);
 
         // Update page number field
-        pageNumberField.setValue(currentPage + 1);
+        pageNumberField.setEnabled(hasContent);
+        pageNumberField.setValue(hasContent ? currentPage + 1 : 1);
         pageNumberField.setMax(totalPages);
 
         // Update page info label
@@ -490,6 +493,9 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver 
         } else {
             postSelector.setItems(new ArrayList<>());
         }
+        boolean hasPosts = currentPageData != null && currentPageData.hasContent();
+        postSelector.setEnabled(hasPosts);
+        postSelector.setPlaceholder(hasPosts ? "Select a post..." : "No completed posts yet");
         postSelector.setValue(null);
     }
 

--- a/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/FileStorageServiceImplTest.java
@@ -54,6 +54,21 @@ class FileStorageServiceImplTest {
     }
 
     @Test
+    void deleteFileDoesNotDeleteOutsideUploadDirectory() throws IOException {
+        FileStorageServiceImpl service = new FileStorageServiceImpl();
+        Path uploadDir = tempDir.resolve("uploads");
+        Files.createDirectories(uploadDir);
+        ReflectionTestUtils.setField(service, "uploadDir", uploadDir.toString());
+
+        Path outsideFile = tempDir.resolve("outside.txt");
+        Files.writeString(outsideFile, "content");
+
+        service.deleteFile("../outside.txt");
+
+        assertTrue(Files.exists(outsideFile));
+    }
+
+    @Test
     void getFileUrlReturnsNullForBlankValuesAndPrefixesBaseUrl() {
         FileStorageServiceImpl service = new FileStorageServiceImpl();
         ReflectionTestUtils.setField(service, "baseUrl", "/files");

--- a/src/test/java/com/afitnerd/tnra/vaadin/PostViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/PostViewTest.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 
@@ -63,6 +64,7 @@ class PostViewTest {
     private Post completedPost1;
     private Post completedPost2;
     private org.springframework.data.domain.Page<Post> completedPostsPage;
+    private org.springframework.data.domain.Page<Post> emptyCompletedPostsPage;
 
     private PostView postView;
 
@@ -95,6 +97,7 @@ class PostViewTest {
         completedPost2.setFinish(new Date(System.currentTimeMillis() - 169200000L)); // finished 1 hour later
 
         completedPostsPage = new PageImpl<>(Arrays.asList(completedPost1, completedPost2));
+        emptyCompletedPostsPage = new PageImpl<>(Collections.emptyList());
 
         // Setup common mocks with lenient stubbing to avoid unnecessary stubbing warnings
         lenient().when(vaadinPostPresenter.initializeUser()).thenReturn(testUser);
@@ -381,6 +384,28 @@ class PostViewTest {
     }
 
     @Test
+    void testCompletedViewWithoutPostsDisablesSelectorAndNormalizesPagination() {
+        lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.empty());
+        lenient().when(vaadinPostPresenter.getCompletedPostsPage(eq(testUser), any(Pageable.class))).thenReturn(emptyCompletedPostsPage);
+
+        try (MockedStatic<UI> mockedUI = mockStatic(UI.class)) {
+            setupUIMocks("America/New_York");
+            mockedUI.when(UI::getCurrent).thenReturn(mockUI);
+
+            postView = new PostView(vaadinPostPresenter);
+            postView.afterNavigation(mockAfterNavigationEvent());
+
+            ComboBox<?> completedPostsSelector = findComponentByClassName(postView, ComboBox.class, "post-selector");
+            assertNotNull(completedPostsSelector, "Completed post selector should exist");
+            assertFalse(completedPostsSelector.isEnabled(), "Completed post selector should be disabled for empty pages");
+
+            Span pageInfo = findComponentByClassName(postView, Span.class, "page-info");
+            assertNotNull(pageInfo, "Page info should be rendered");
+            assertTrue(pageInfo.getText().contains("of 1"), "Empty pagination should display one normalized page");
+        }
+    }
+
+    @Test
     void testFormFieldsExist() {
         // Arrange
         lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.of(inProgressPost));
@@ -554,6 +579,21 @@ class PostViewTest {
             }
         }
         return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T extends Component> T findComponentByClassName(Component parent, Class<T> componentType, String className) {
+        if (componentType.isInstance(parent) && parent.getClassNames().contains(className)) {
+            return (T) parent;
+        }
+
+        for (Component child : parent.getChildren().toArray(Component[]::new)) {
+            T result = findComponentByClassName(child, componentType, className);
+            if (result != null) {
+                return result;
+            }
+        }
+        return null;
     }
 
     private void invokeMethod(Object target, String methodName) {


### PR DESCRIPTION
## Summary
- Harden backend file deletion by normalizing/resolving paths and blocking deletes outside the configured upload directory.
- Improve completed-posts UI when no posts exist by disabling post selection/pagination input and normalizing page display to "of 1".
- Preserve existing behavior for non-empty completed-post pages.

## Tests
- ./mvnw test (full suite)
- ./mvnw -Dtest=FileStorageServiceImplTest,PostViewTest test

## Notes
- This is scoped to one backend hardening improvement and one UI usability/edge-case improvement for this automation run.
