### PR TITLE
Improve GTG notifications and main view navigation

### DIFF
--- a/src/main/java/com/afitnerd/tnra/controller/APIController.java
+++ b/src/main/java/com/afitnerd/tnra/controller/APIController.java
@@ -75,7 +75,7 @@ public class APIController {
             eMailService.sendTextViaMail(gtgPair.getCallee(), calleePost);
             // send callee what and when
             Post callerPost = postService.getLastFinishedPost(gtgPair.getCaller());
-            eMailService.sendTextViaMail(gtgPair.getCallee(), callerPost);
+            eMailService.sendTextViaMail(gtgPair.getCaller(), callerPost);
             //}
         });
         return goToGuySet;

--- a/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
@@ -114,10 +114,12 @@ public class MainView extends VerticalLayout {
                 "Hello, " + resolvedDisplayName + "! You are now logged in."
             );
             welcomeMessage.addClassName("welcome-message");
+
+            HorizontalLayout quickActions = createQuickActions();
             
             profileSection.add(profileImage, welcomeMessage);
             
-            add(title, profileSection);
+            add(title, profileSection, quickActions);
         } catch (Exception e) {
             // Fallback to simple view if there's an error
             H1 title = new H1("Welcome back!");
@@ -137,6 +139,33 @@ public class MainView extends VerticalLayout {
 
             log.warn("Error while rendering authenticated main view", e);
         }
+    }
+
+    private HorizontalLayout createQuickActions() {
+        HorizontalLayout quickActions = new HorizontalLayout();
+        quickActions.addClassName("main-quick-actions");
+        quickActions.setSpacing(true);
+
+        Button openPostsButton = new Button("Open Posts", click ->
+            getUI().ifPresent(ui -> ui.navigate("posts"))
+        );
+        openPostsButton.addClassName("main-action-button");
+        openPostsButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+
+        Button viewStatsButton = new Button("View Stats", click ->
+            getUI().ifPresent(ui -> ui.navigate("stats"))
+        );
+        viewStatsButton.addClassName("main-action-button");
+        viewStatsButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+
+        Button updateProfileButton = new Button("Update Profile", click ->
+            getUI().ifPresent(ui -> ui.navigate("profile"))
+        );
+        updateProfileButton.addClassName("main-action-button");
+        updateProfileButton.addThemeVariants(ButtonVariant.LUMO_TERTIARY);
+
+        quickActions.add(openPostsButton, viewStatsButton, updateProfileButton);
+        return quickActions;
     }
 
     private String resolveDisplayName(String displayName, User currentUser) {

--- a/src/main/resources/META-INF/resources/frontend/styles/main-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/main-view.css
@@ -71,3 +71,31 @@
 .main-profile-image:hover {
     border-color: var(--tnra-accent);
 }
+
+.main-quick-actions {
+    margin-top: 0.75rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.main-action-button {
+    min-width: 11rem;
+    font-weight: 600;
+}
+
+@media (max-width: 640px) {
+    .profile-section {
+        flex-direction: column;
+        text-align: center;
+        padding: 1rem;
+    }
+
+    .main-quick-actions {
+        width: 100%;
+    }
+
+    .main-action-button {
+        width: 100%;
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/controller/APIControllerTest.java
+++ b/src/test/java/com/afitnerd/tnra/controller/APIControllerTest.java
@@ -77,7 +77,7 @@ class APIControllerTest {
 
         assertSame(gtgSet, returned);
         verify(eMailService).sendTextViaMail(callee, calleePost);
-        verify(eMailService).sendTextViaMail(callee, callerPost);
+        verify(eMailService).sendTextViaMail(caller, callerPost);
     }
 
     @Test

--- a/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
@@ -254,4 +254,29 @@ class MainViewTest {
 
         assertTrue(hasLoginButton, "Expected unauthenticated view to include a log in button");
     }
+
+    @Test
+    void testMainViewShowsQuickActionButtonsForAuthenticatedUsers() {
+        when(oidcUserService.isAuthenticated()).thenReturn(true);
+        when(oidcUserService.getDisplayName()).thenReturn("Test User");
+        when(userService.getCurrentUser()).thenReturn(testUser);
+
+        mainView = new MainView(oidcUserService, userService, fileStorageService, authNavigationService);
+
+        boolean hasOpenPosts = containsButtonWithText("Open Posts");
+        boolean hasViewStats = containsButtonWithText("View Stats");
+        boolean hasUpdateProfile = containsButtonWithText("Update Profile");
+
+        assertTrue(hasOpenPosts, "Expected authenticated view to include an Open Posts action");
+        assertTrue(hasViewStats, "Expected authenticated view to include a View Stats action");
+        assertTrue(hasUpdateProfile, "Expected authenticated view to include an Update Profile action");
+    }
+
+    private boolean containsButtonWithText(String text) {
+        return mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .filter(component -> component instanceof Button)
+            .map(component -> (Button) component)
+            .anyMatch(button -> text.equals(button.getText()));
+    }
 }


### PR DESCRIPTION
## Summary
- fix GTG notification recipient routing so caller and callee each receive their own post summary
- add authenticated quick actions on the main page for Posts, Stats, and Profile
- improve main view responsive styles for quick actions and profile section on mobile
- add/adjust tests for notification recipient behavior and authenticated quick actions

## Validation
- ./mvnw test (289 tests passing)