### PR TITLE
Improve main view quick actions and API post safety

### DIFF
--- a/src/main/java/com/afitnerd/tnra/controller/APIController.java
+++ b/src/main/java/com/afitnerd/tnra/controller/APIController.java
@@ -12,6 +12,7 @@ import com.afitnerd.tnra.service.SlackPostRenderer;
 import com.afitnerd.tnra.slack.service.SlackAPIService;
 import com.fasterxml.jackson.annotation.JsonView;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -75,7 +76,7 @@ public class APIController {
             eMailService.sendTextViaMail(gtgPair.getCallee(), calleePost);
             // send callee what and when
             Post callerPost = postService.getLastFinishedPost(gtgPair.getCaller());
-            eMailService.sendTextViaMail(gtgPair.getCallee(), callerPost);
+            eMailService.sendTextViaMail(gtgPair.getCaller(), callerPost);
             //}
         });
         return goToGuySet;
@@ -118,7 +119,22 @@ public class APIController {
 
     @PostMapping("/in_progress")
     Post updatePost(Principal me, @RequestBody Post post) {
+        User currentUser = userRepository.findByEmail(me.getName());
+        if (post.getUser() != null && !isCurrentUser(post.getUser(), currentUser)) {
+            throw new IllegalArgumentException("Post user does not match current user");
+        }
+        post.setUser(currentUser);
         return postService.savePost(post);
+    }
+
+    private boolean isCurrentUser(User postUser, User currentUser) {
+        if (postUser.getId() != null && currentUser.getId() != null) {
+            return postUser.getId().equals(currentUser.getId());
+        }
+        if (StringUtils.hasText(postUser.getEmail()) && StringUtils.hasText(currentUser.getEmail())) {
+            return postUser.getEmail().trim().equalsIgnoreCase(currentUser.getEmail().trim());
+        }
+        return false;
     }
 
     @GetMapping("/complete")

--- a/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/MainView.java
@@ -8,6 +8,7 @@ import com.afitnerd.tnra.service.UserService;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.dependency.CssImport;
+import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Image;
@@ -116,8 +117,10 @@ public class MainView extends VerticalLayout {
             welcomeMessage.addClassName("welcome-message");
             
             profileSection.add(profileImage, welcomeMessage);
-            
-            add(title, profileSection);
+
+            VerticalLayout actionSection = createActionSection();
+
+            add(title, profileSection, actionSection);
         } catch (Exception e) {
             // Fallback to simple view if there's an error
             H1 title = new H1("Welcome back!");
@@ -132,11 +135,39 @@ public class MainView extends VerticalLayout {
                 "Note: Could not retrieve user details due to an error."
             );
             errorMessage.addClassName("error-message");
-            
-            add(title, welcomeMessage, errorMessage);
+
+            VerticalLayout actionSection = createActionSection();
+
+            add(title, welcomeMessage, errorMessage, actionSection);
 
             log.warn("Error while rendering authenticated main view", e);
         }
+    }
+
+    private VerticalLayout createActionSection() {
+        VerticalLayout actionSection = new VerticalLayout();
+        actionSection.setSpacing(false);
+        actionSection.setPadding(false);
+        actionSection.setAlignItems(Alignment.CENTER);
+        actionSection.addClassName("main-action-section");
+
+        H2 actionTitle = new H2("Quick actions");
+        actionTitle.addClassName("main-action-title");
+
+        HorizontalLayout links = new HorizontalLayout();
+        links.setSpacing(true);
+        links.addClassName("main-action-links");
+
+        Anchor postsLink = new Anchor("/posts", "Open posts");
+        postsLink.addClassName("main-action-link");
+        Anchor statsLink = new Anchor("/stats", "View stats");
+        statsLink.addClassName("main-action-link");
+        Anchor profileLink = new Anchor("/profile", "Update profile");
+        profileLink.addClassName("main-action-link");
+
+        links.add(postsLink, statsLink, profileLink);
+        actionSection.add(actionTitle, links);
+        return actionSection;
     }
 
     private String resolveDisplayName(String displayName, User currentUser) {

--- a/src/main/resources/META-INF/resources/frontend/styles/main-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/main-view.css
@@ -71,3 +71,59 @@
 .main-profile-image:hover {
     border-color: var(--tnra-accent);
 }
+
+.main-action-section {
+    margin-top: 1rem;
+    width: 100%;
+    max-width: 42rem;
+}
+
+.main-action-title {
+    color: var(--tnra-text);
+    font-size: 1.1rem;
+    margin: 0 0 0.75rem;
+}
+
+.main-action-links {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.main-action-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 9rem;
+    padding: 0.6rem 1rem;
+    border-radius: var(--tnra-radius-sm);
+    border: 1px solid var(--tnra-border-subtle);
+    color: var(--tnra-text);
+    background: var(--tnra-surface);
+    text-decoration: none;
+    font-weight: 600;
+    transition: all var(--tnra-transition);
+}
+
+.main-action-link:hover {
+    border-color: var(--tnra-primary);
+    box-shadow: var(--tnra-shadow-sm);
+}
+
+@media (max-width: 640px) {
+    .profile-section {
+        flex-direction: column;
+        text-align: center;
+        width: 100%;
+    }
+
+    .main-action-links {
+        width: 100%;
+        flex-direction: column;
+    }
+
+    .main-action-link {
+        width: 100%;
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/controller/APIControllerTest.java
+++ b/src/test/java/com/afitnerd/tnra/controller/APIControllerTest.java
@@ -22,7 +22,10 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -77,7 +80,7 @@ class APIControllerTest {
 
         assertSame(gtgSet, returned);
         verify(eMailService).sendTextViaMail(callee, calleePost);
-        verify(eMailService).sendTextViaMail(callee, callerPost);
+        verify(eMailService).sendTextViaMail(caller, callerPost);
     }
 
     @Test
@@ -85,17 +88,33 @@ class APIControllerTest {
         APIController controller = controller();
         Principal principal = () -> "user@example.com";
         User user = new User("Test", "User", "user@example.com");
+        user.setId(1L);
         Post post = new Post(user);
         when(userRepository.findByEmail("user@example.com")).thenReturn(user);
         when(postService.getOptionalInProgressPost(user)).thenReturn(Optional.of(post));
         when(postService.getOptionalCompletePost(user)).thenReturn(Optional.of(post));
         when(postService.startPost(user)).thenReturn(post);
-        when(postService.savePost(post)).thenReturn(post);
+        when(postService.savePost(argThat(saved -> saved.getUser() == user))).thenReturn(post);
 
         assertEquals(Optional.of(post), controller.getInProgressPost(principal));
         assertSame(post, controller.updatePost(principal, post));
         assertEquals(Optional.of(post), controller.getCompletePost(principal));
         assertSame(post, controller.startPost(principal));
+    }
+
+    @Test
+    void updatePostRejectsOtherUsersPost() {
+        APIController controller = controller();
+        Principal principal = () -> "user@example.com";
+        User currentUser = new User("Current", "User", "user@example.com");
+        currentUser.setId(1L);
+        User otherUser = new User("Other", "User", "other@example.com");
+        otherUser.setId(2L);
+        Post post = new Post(otherUser);
+        when(userRepository.findByEmail("user@example.com")).thenReturn(currentUser);
+
+        assertThrows(IllegalArgumentException.class, () -> controller.updatePost(principal, post));
+        verify(postService, never()).savePost(any(Post.class));
     }
 
     @Test

--- a/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/MainViewTest.java
@@ -6,6 +6,7 @@ import com.afitnerd.tnra.service.FileStorageService;
 import com.afitnerd.tnra.service.OidcUserService;
 import com.afitnerd.tnra.service.UserService;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.html.Anchor;
 import com.vaadin.flow.component.html.H1;
 import com.vaadin.flow.component.html.H2;
 import com.vaadin.flow.component.html.Image;
@@ -253,5 +254,22 @@ class MainViewTest {
             .anyMatch(component -> component instanceof Button && "Log in".equals(((Button) component).getText()));
 
         assertTrue(hasLoginButton, "Expected unauthenticated view to include a log in button");
+    }
+
+    @Test
+    void testAuthenticatedViewShowsQuickActionLinks() {
+        when(oidcUserService.isAuthenticated()).thenReturn(true);
+        when(oidcUserService.getDisplayName()).thenReturn("Test User");
+        when(userService.getCurrentUser()).thenReturn(testUser);
+
+        mainView = new MainView(oidcUserService, userService, fileStorageService, authNavigationService);
+
+        long actionLinkCount = mainView.getChildren()
+            .flatMap(component -> component.getChildren())
+            .flatMap(component -> component.getChildren())
+            .filter(component -> component instanceof Anchor)
+            .count();
+
+        assertEquals(3, actionLinkCount, "Expected quick action links for posts, stats, and profile");
     }
 }


### PR DESCRIPTION
## Summary
- fix `/api/v1/notify_what_and_whens` so caller and callee each receive the correct post
- harden `/api/v1/in_progress` updates by rejecting mismatched post ownership and binding saves to current user
- improve authenticated `MainView` with quick action links and responsive mobile styling
- add/adjust tests for API behavior and authenticated quick actions

## Testing
- ./mvnw test
