### PR TITLE
feat: Slack Part 1 — activity-only webhook notification on post completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to TNRA are documented in this file.
 
+## [8.1.0] - 2026-04-25
+
+### Added
+- **Encrypted post deep links.** Raw database IDs are no longer exposed in post URLs. A new `PostTokenService` encrypts each `Long` post ID using the existing AES-256-GCM DEK and encodes the result as URL-safe base64 (no `+`, `/`, or `=` padding). `PostView` now accepts `HasUrlParameter<String>` and decodes the token server-side before fetching the post; invalid or tampered tokens fall through to the default view with no information leaked. Both Slack notifications (`SlackNotificationServiceImpl`) and email notifications (`ActivityNotificationRenderer`) now generate tokenised URLs.
+- **`PostTokenService` / `PostTokenServiceImpl`.** Standalone encode/decode service. Encode: `encrypt(id.toString())` → strip `ENC:` prefix → convert standard base64 to URL-safe base64url (no padding). Decode: reverse the base64url mapping → restore padding → prepend `ENC:` → `decrypt()` → `Long.parseLong()`. Any exception in this chain throws `IllegalArgumentException`.
+- **542 unit tests.** 7 new `PostTokenServiceImplTest` tests cover padding strips, character substitution, round-trip, URL-safety, and two error paths. `PostViewTest` updated with 30 two-arg constructor calls and a new `testDeepLinkWithInvalidTokenFallsThroughToDefault` test.
+
+### Security
+- Sequential integer IDs no longer appear in Slack messages, email notifications, or browser URLs. Authenticated users cannot enumerate posts by incrementing a URL parameter.
+
 ## [8.0.3] - 2026-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -333,6 +333,51 @@ Login navigation is configurable through `AuthNavigationService`:
 Resolution order: `login-path` > `/oauth2/authorization/{login-registration-id}` >
 `/oauth2/authorization/keycloak`
 
+## Slack Integration
+
+TNRA uses [Slack Incoming Webhooks](https://api.slack.com/messaging/webhooks) — a one-way
+push mechanism that requires no bot token, no OAuth flow, and no Slack app review. When
+enabled, a notification fires each time a member finishes a post:
+
+```
+[First Last] finished a post | Started: 2024-01-15 08:30 | Finished: 2024-01-15 09:15 | View: https://…
+```
+
+No post content is included. Only the activity metadata (who, when, link) leaves the app.
+
+> **Compared to the v4.x integration:** The old implementation required a Slack bot access
+> token (`xoxb-…`), a broadcast channel ID, and a separate Slack token — these had to be
+> managed as app credentials and involved OAuth scopes. The webhook approach used here is
+> simpler: one URL, tied to a channel at creation time, no credentials stored beyond the URL
+> itself (which is encrypted at rest with AES-256-GCM).
+
+### Setting up a Slack webhook
+
+1. Go to [https://api.slack.com/apps](https://api.slack.com/apps) and click **Create New App → From scratch**.
+2. Name the app (e.g., `TNRA Notifications`) and select your workspace. Click **Create App**.
+3. In the left sidebar under **Features**, click **Incoming Webhooks**.
+4. Toggle **Activate Incoming Webhooks** to **On**.
+5. Click **Add New Webhook to Workspace**.
+6. Select the channel where post-completion notifications should appear (e.g., `#accountability`). Click **Allow**.
+7. Copy the generated webhook URL — it follows the pattern:
+   ```
+   https://hooks.slack.com/services/<workspace-id>/<channel-id>/<token>
+   ```
+   Keep this URL private; anyone with it can post to your channel.
+
+### Configuring TNRA
+
+1. Log in as a group admin and open the **Admin** panel.
+2. Click the **Integrations** tab.
+3. Paste the webhook URL into the **Slack Webhook URL** field.
+4. Check **Slack notifications enabled**.
+5. Click **Save**.
+
+Notifications fire asynchronously and never block the member's post submission. Errors
+(e.g., invalid URL, network failure) are logged server-side and do not surface to the user.
+
+To disable notifications without losing the URL, uncheck **Slack notifications enabled** and save.
+
 ## Database Migrations (Flyway)
 
 Migration files: `src/main/resources/db/migration/`
@@ -349,6 +394,7 @@ Migration files: `src/main/resources/db/migration/`
 | V8 | (Java) Encrypt existing post and stat data in-place |
 | V9 | Widen stat_definition.emoji to TEXT |
 | V10 | (Java) Encrypt existing emoji values in-place |
+| V11 | Group settings (Slack webhook URL encrypted, enabled flag) |
 
 Flyway runs automatically on startup. `baseline-on-migrate: true` handles pre-Flyway databases.
 Hibernate `ddl-auto: validate` ensures schema matches entities without modifying the database.

--- a/TODOS.md
+++ b/TODOS.md
@@ -15,7 +15,7 @@ Admin-configurable incoming webhook for a Slack channel. When a member finishes 
 - **Depends on:** Encryption deployed to active group. Deep links shipped (v7.5.0). `group_settings` table for storing webhook URL + enabled flag.
 - **Context:** Use Slack incoming webhooks (no OAuth, no slash commands). One webhook URL per group, stored encrypted in `group_settings`. Admin UI in the Admin panel to configure the webhook URL and toggle on/off. Message format: `[username] finished a post | Started: [time] | Finished: [time] | View: [deep link URL]`. No post content, no stats — activity signal only.
 
-### Deep Link URL Token — Obfuscate Post ID in Shared Links
+### ~~Deep Link URL Token — Obfuscate Post ID in Shared Links~~ ✓ Completed v8.1.0
 Replace the raw database ID in post deep links (`/post/42`) with an AES-GCM-encrypted, base64url-encoded token so sequential IDs are never exposed externally.
 - **Why:** Sequential integer IDs in URLs allow enumeration attacks — an authenticated user can increment the ID to probe posts that aren't theirs. Slack notifications make this worse by broadcasting the link to an entire channel.
 - **Effort:** S (human: ~1 day / CC: ~15 min)

--- a/TODOS.md
+++ b/TODOS.md
@@ -1,14 +1,33 @@
 # TODOS
 
-## P1.5 — Branch 5 (Landing Page + Encryption)
+## P1.5 — Branch 5 (Next Up)
 
+### [NEXT] Deploy Encryption to Active Group
+Roll out v8.0.3 to the current active group for real-world testing before new features land.
+- **Why:** Validates encryption migrations, JPA converters, and master key config in production before the user base grows.
+- **Effort:** XS (human: ~1 hour / CC: n/a — ops task)
+- **Context:** Run Flyway V7–V10 migrations against the live DB. Confirm encrypted columns read/write correctly via the UI. Master key must be set in the group's `.env`. This is a gate before Slack Part 1 ships.
+
+### Slack Integration — Part 1: Activity-Only with Post Link
+Admin-configurable incoming webhook for a Slack channel. When a member finishes a post, post a message to the configured channel containing: username, start time, finish time, and a deep link to the post.
+- **Why:** Gives groups immediate visibility into posting activity without exposing encrypted post content outside the DB. Deep link enforces authentication before content is visible.
+- **Effort:** S (human: ~2 days / CC: ~20 min)
+- **Depends on:** Encryption deployed to active group. Deep links shipped (v7.5.0). `group_settings` table for storing webhook URL + enabled flag.
+- **Context:** Use Slack incoming webhooks (no OAuth, no slash commands). One webhook URL per group, stored encrypted in `group_settings`. Admin UI in the Admin panel to configure the webhook URL and toggle on/off. Message format: `[username] finished a post | Started: [time] | Finished: [time] | View: [deep link URL]`. No post content, no stats — activity signal only.
 
 ### Landing Page with Request Access Form
 Static or Vaadin public route for prospective groups. Form: group name, contact name, email, estimated size, description. Submissions stored in `request_access` table + email notification to founder.
 - **Why:** Need somewhere to point prospective groups. Supports go-to-market.
 - **Effort:** S (human: ~2 days / CC: ~15 min)
-- **Depends on:** Branch 4 shipped.
+- **Depends on:** Slack Part 1 shipped.
 - **Context:** Requires Spring Security rule for anonymous access without exposing other routes. Rate limiting on form (max 5/hour per IP).
+
+### Slack Integration — Part 2: Stats and Full-Post Tiers
+Extend Part 1 with two additional admin-selectable content tiers: stats-only (username + stat values, no narrative text) and full-post (all post sections, decrypted at send time). Admin selects tier per group.
+- **Why:** Groups that are comfortable with the trade-off can opt into richer Slack notifications.
+- **Effort:** S-M (human: ~2 days / CC: ~20 min)
+- **Depends on:** Slack Part 1 shipped, landing page shipped, at least one group providing feedback on Part 1.
+- **Context:** Tier selection stored in `group_settings`. Full-post tier decrypts content in-memory before sending to Slack — clear security warning in the admin UI that post content will leave the encrypted DB. Stats-only tier sends stat names + values only (no narrative). Slack message layout adapts per tier.
 
 ## P2 — After MVP Ships
 
@@ -33,13 +52,6 @@ Monthly meeting notes as a rich-text field per month, viewable by all group memb
 - **Depends on:** Core wedge (encryption, configurable stats, Keycloak, provisioning) shipped.
 - **Context:** Monthly cadence involves a group meeting to review and make new commitments. Notes are currently unstructured in Google Docs. Rich-text editing in Vaadin requires a component (e.g., CKEditor or similar).
 
-### Slack Integration (Optional Per-Group)
-Re-introduce Slack integration as an opt-in feature for groups that use Slack.
-- **Why:** Removed from MVP to simplify provisioning. Not every group uses Slack (faith/recovery groups often don't).
-- **Effort:** M (human: ~1 week / CC: ~30 min)
-- **Depends on:** Core wedge shipped, at least one group onboarded.
-- **Context:** Current implementation has slash commands, broadcast channel, and API service. Per-group Slack app provisioning would need to be added to the CLI. Activity-only notifications (no post content) to align with encryption-at-rest security posture.
-
 ### Text/SMS Notifications (Rebuild from Scratch)
 Proper SMS notifications using a real provider (Twilio, AWS SNS, or similar).
 - **Why:** Current implementation uses brittle carrier email-to-text gateways (e.g., `number@vtext.com`). Unreliable delivery, no confirmation, carrier-dependent. Must be rebuilt properly, not restored.
@@ -58,7 +70,7 @@ Refine deactivated user behavior: allow login in read-only mode to view own post
 
 ### Yearly Retreat Prep Format
 Structured annual reflection form per member per year, viewable by the group.
-- **Why:** The yearly retreat is the anchor event for TNRA groups. A specific prep format exists in practice but isn't digitized.
+- **Why:** The yearly retreat is the anchor event for TNRA groups. A specific proto-format exists in practice but isn't digitized.
 - **Effort:** S-M (human: ~3 days / CC: ~30 min)
 - **Depends on:** Core wedge shipped, at least one group onboarded.
 - **Context:** Recovery and faith groups often build their year around the retreat. Having the prep format built in signals TNRA understands the full cadence. Similar to the weekly post form but for annual reflection.

--- a/TODOS.md
+++ b/TODOS.md
@@ -15,6 +15,13 @@ Admin-configurable incoming webhook for a Slack channel. When a member finishes 
 - **Depends on:** Encryption deployed to active group. Deep links shipped (v7.5.0). `group_settings` table for storing webhook URL + enabled flag.
 - **Context:** Use Slack incoming webhooks (no OAuth, no slash commands). One webhook URL per group, stored encrypted in `group_settings`. Admin UI in the Admin panel to configure the webhook URL and toggle on/off. Message format: `[username] finished a post | Started: [time] | Finished: [time] | View: [deep link URL]`. No post content, no stats — activity signal only.
 
+### Deep Link URL Token — Obfuscate Post ID in Shared Links
+Replace the raw database ID in post deep links (`/post/42`) with an AES-GCM-encrypted, base64url-encoded token so sequential IDs are never exposed externally.
+- **Why:** Sequential integer IDs in URLs allow enumeration attacks — an authenticated user can increment the ID to probe posts that aren't theirs. Slack notifications make this worse by broadcasting the link to an entire channel.
+- **Effort:** S (human: ~1 day / CC: ~15 min)
+- **Depends on:** Slack Part 1 shipped. Encryption infrastructure already in place (V7/V8 migrations, `EncryptedStringConverter`).
+- **Context:** Reuse the existing AES-256-GCM service to encrypt the `Long` post ID (serialize as a string, encrypt, base64url-encode for URL safety). Expose a `PostTokenService` (or method on the existing crypto service) with `encode(Long id)` and `decode(String token)`. Update the PostView router to decode the token before fetching. Update `SlackNotificationServiceImpl.buildMessage()` to encode the ID when constructing the deep link. The existing `/post/{id}` route stays but checks ownership; the token route is the new public-facing path. Decryption failure or post-not-found both return 404 — no information leakage.
+
 ### Landing Page with Request Access Form
 Static or Vaadin public route for prospective groups. Form: group name, contact name, email, estimated size, description. Submissions stored in `request_access` table + email notification to founder.
 - **Why:** Need somewhere to point prospective groups. Supports go-to-market.
@@ -37,6 +44,13 @@ The completed post view renders post fields in a disabled/read-only state that p
 - **Effort:** XS (human: ~2 hours / CC: ~10 min)
 - **Depends on:** Nothing — purely visual, no data model changes.
 - **Context:** Read-only Vaadin `TextArea` and `TextField` components use a muted disabled style by default. Fix by switching to a custom CSS approach (e.g., `pointer-events: none` + explicit text color override via Lumo custom properties or a `.read-only-field` theme variant) so the fields look rendered rather than grayed-out. Evaluate against DESIGN.md before shipping.
+
+### Non-Sequential Primary Keys
+Add a `public_id` UUID column to all externally-visible entities (Post, User) so that internal sequential auto-increment PKs are never surfaced in the API, URLs, or notifications.
+- **Why:** Sequential integer PKs reveal row count, insertion rate, and allow trivial enumeration. UUID public IDs eliminate all three. Complements the deep-link token work but covers entities beyond just posts (e.g., user profile routes).
+- **Effort:** M (human: ~2 days / CC: ~20 min)
+- **Depends on:** Deep Link URL Token task shipped (establishes the pattern). No Flyway version conflict at the time this is scheduled.
+- **Context:** Add `public_id CHAR(36) NOT NULL DEFAULT (UUID())` columns via a new Flyway migration. Populate existing rows in the same migration. Add a `@Column(unique=true)` `publicId` field to affected JPA entities. Internal foreign keys and JPA relationships keep the numeric PK for performance — only the `publicId` is ever sent over the wire or stored in external systems. Update repositories with `findByPublicId(String)` finders. Audit all Vaadin views and service methods to confirm no numeric ID leaks remain.
 
 ### Email Invitation Flow
 Send Keycloak registration link when admin invites a member.

--- a/TODOS.md
+++ b/TODOS.md
@@ -31,6 +31,13 @@ Extend Part 1 with two additional admin-selectable content tiers: stats-only (us
 
 ## P2 — After MVP Ships
 
+### Completed Post View — Improve Read-Only Contrast
+The completed post view renders post fields in a disabled/read-only state that produces low-contrast text, making content hard to read.
+- **Why:** Members frequently review past posts; poor legibility undermines the core use case.
+- **Effort:** XS (human: ~2 hours / CC: ~10 min)
+- **Depends on:** Nothing — purely visual, no data model changes.
+- **Context:** Read-only Vaadin `TextArea` and `TextField` components use a muted disabled style by default. Fix by switching to a custom CSS approach (e.g., `pointer-events: none` + explicit text color override via Lumo custom properties or a `.read-only-field` theme variant) so the fields look rendered rather than grayed-out. Evaluate against DESIGN.md before shipping.
+
 ### Email Invitation Flow
 Send Keycloak registration link when admin invites a member.
 - **Why:** Currently admin enters an email and tells the member out-of-band to create a Keycloak account. An email invitation with a registration link is the expected UX.

--- a/src/main/java/com/afitnerd/tnra/TnraApplication.java
+++ b/src/main/java/com/afitnerd/tnra/TnraApplication.java
@@ -57,6 +57,19 @@ public class TnraApplication implements AppShellConfigurator {
         return executor;
     }
 
+    @Bean
+    public TaskExecutor slackTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("slack-");
+        executor.setRejectedExecutionHandler(new java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy());
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(15);
+        return executor;
+    }
+
     public static void main(String[] args) {
         SpringApplication.run(TnraApplication.class, args);
     }

--- a/src/main/java/com/afitnerd/tnra/model/GroupSettings.java
+++ b/src/main/java/com/afitnerd/tnra/model/GroupSettings.java
@@ -1,0 +1,48 @@
+package com.afitnerd.tnra.model;
+
+import com.afitnerd.tnra.model.converter.EncryptedStringConverter;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.util.Date;
+
+@Entity
+@Table(name = "group_settings")
+public class GroupSettings {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Convert(converter = EncryptedStringConverter.class)
+    @Column(name = "slack_webhook_url", columnDefinition = "TEXT")
+    private String slackWebhookUrl;
+
+    @Column(name = "slack_enabled")
+    private boolean slackEnabled;
+
+    @Column(name = "created_at")
+    private Date createdAt;
+
+    @Column(name = "updated_at")
+    private Date updatedAt;
+
+    public Long getId() { return id; }
+
+    public String getSlackWebhookUrl() { return slackWebhookUrl; }
+    public void setSlackWebhookUrl(String slackWebhookUrl) { this.slackWebhookUrl = slackWebhookUrl; }
+
+    public boolean isSlackEnabled() { return slackEnabled; }
+    public void setSlackEnabled(boolean slackEnabled) { this.slackEnabled = slackEnabled; }
+
+    public Date getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public Date getUpdatedAt() { return updatedAt; }
+    public void setUpdatedAt(Date updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/src/main/java/com/afitnerd/tnra/model/GroupSettings.java
+++ b/src/main/java/com/afitnerd/tnra/model/GroupSettings.java
@@ -27,10 +27,10 @@ public class GroupSettings {
     private boolean slackEnabled;
 
     @Column(name = "created_at")
-    private Date createdAt;
+    private Date createdAt = new Date();
 
     @Column(name = "updated_at")
-    private Date updatedAt;
+    private Date updatedAt = new Date();
 
     public Long getId() { return id; }
 

--- a/src/main/java/com/afitnerd/tnra/repository/GroupSettingsRepository.java
+++ b/src/main/java/com/afitnerd/tnra/repository/GroupSettingsRepository.java
@@ -1,0 +1,10 @@
+package com.afitnerd.tnra.repository;
+
+import com.afitnerd.tnra.model.GroupSettings;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface GroupSettingsRepository extends JpaRepository<GroupSettings, Long> {
+    Optional<GroupSettings> findFirstByOrderByIdAsc();
+}

--- a/src/main/java/com/afitnerd/tnra/service/ActivityNotificationRenderer.java
+++ b/src/main/java/com/afitnerd/tnra/service/ActivityNotificationRenderer.java
@@ -8,11 +8,14 @@ import org.springframework.stereotype.Service;
 @Service("activityNotificationRenderer")
 public class ActivityNotificationRenderer implements PostRenderer {
 
+    private final PostTokenService postTokenService;
     private final String baseUrl;
 
     public ActivityNotificationRenderer(
+        PostTokenService postTokenService,
         @Value("${tnra.app.base-url:http://localhost:8080}") String baseUrl
     ) {
+        this.postTokenService = postTokenService;
         this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
     }
 
@@ -33,7 +36,7 @@ public class ActivityNotificationRenderer implements PostRenderer {
         }
         sb.append(".</p>");
         if (post.getId() != null) {
-            String postLink = baseUrl + "/posts/" + post.getId();
+            String postLink = baseUrl + "/posts/" + postTokenService.encode(post.getId());
             sb.append("<p><a href=\"").append(escapeHtml(postLink));
             sb.append("\">View post</a></p>");
         } else {

--- a/src/main/java/com/afitnerd/tnra/service/GroupSettingsService.java
+++ b/src/main/java/com/afitnerd/tnra/service/GroupSettingsService.java
@@ -1,0 +1,8 @@
+package com.afitnerd.tnra.service;
+
+import com.afitnerd.tnra.model.GroupSettings;
+
+public interface GroupSettingsService {
+    GroupSettings getSettings();
+    GroupSettings save(GroupSettings settings);
+}

--- a/src/main/java/com/afitnerd/tnra/service/GroupSettingsServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/GroupSettingsServiceImpl.java
@@ -1,0 +1,25 @@
+package com.afitnerd.tnra.service;
+
+import com.afitnerd.tnra.model.GroupSettings;
+import com.afitnerd.tnra.repository.GroupSettingsRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class GroupSettingsServiceImpl implements GroupSettingsService {
+
+    private final GroupSettingsRepository repository;
+
+    public GroupSettingsServiceImpl(GroupSettingsRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public GroupSettings getSettings() {
+        return repository.findFirstByOrderByIdAsc().orElseGet(GroupSettings::new);
+    }
+
+    @Override
+    public GroupSettings save(GroupSettings settings) {
+        return repository.save(settings);
+    }
+}

--- a/src/main/java/com/afitnerd/tnra/service/PostTokenService.java
+++ b/src/main/java/com/afitnerd/tnra/service/PostTokenService.java
@@ -1,0 +1,6 @@
+package com.afitnerd.tnra.service;
+
+public interface PostTokenService {
+    String encode(Long postId);
+    Long decode(String token); // throws IllegalArgumentException on invalid/tampered token
+}

--- a/src/main/java/com/afitnerd/tnra/service/PostTokenServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/PostTokenServiceImpl.java
@@ -1,0 +1,34 @@
+package com.afitnerd.tnra.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class PostTokenServiceImpl implements PostTokenService {
+
+    private final EncryptionService encryptionService;
+
+    public PostTokenServiceImpl(EncryptionService encryptionService) {
+        this.encryptionService = encryptionService;
+    }
+
+    @Override
+    public String encode(Long postId) {
+        String encrypted = encryptionService.encrypt(postId.toString());
+        // encrypted = "ENC:" + standard_base64
+        String base64 = encrypted.substring("ENC:".length());
+        return base64.replace('+', '-').replace('/', '_').replaceAll("=+$", "");
+    }
+
+    @Override
+    public Long decode(String token) {
+        try {
+            String base64 = token.replace('-', '+').replace('_', '/');
+            int pad = (4 - base64.length() % 4) % 4;
+            base64 += "=".repeat(pad);
+            String decrypted = encryptionService.decrypt("ENC:" + base64);
+            return Long.parseLong(decrypted);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid post token", e);
+        }
+    }
+}

--- a/src/main/java/com/afitnerd/tnra/service/SlackNotificationService.java
+++ b/src/main/java/com/afitnerd/tnra/service/SlackNotificationService.java
@@ -1,0 +1,7 @@
+package com.afitnerd.tnra.service;
+
+import com.afitnerd.tnra.model.Post;
+
+public interface SlackNotificationService {
+    void sendActivityNotification(Post post);
+}

--- a/src/main/java/com/afitnerd/tnra/service/SlackNotificationServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/SlackNotificationServiceImpl.java
@@ -1,0 +1,88 @@
+package com.afitnerd.tnra.service;
+
+import com.afitnerd.tnra.model.GroupSettings;
+import com.afitnerd.tnra.model.Post;
+import com.afitnerd.tnra.model.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.hc.client5.http.fluent.Request;
+import org.apache.hc.core5.http.ContentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+@Service
+public class SlackNotificationServiceImpl implements SlackNotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(SlackNotificationServiceImpl.class);
+
+    private final GroupSettingsService groupSettingsService;
+    private final String baseUrl;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public SlackNotificationServiceImpl(
+        GroupSettingsService groupSettingsService,
+        @Value("${tnra.app.base-url:http://localhost:8080}") String baseUrl
+    ) {
+        this.groupSettingsService = groupSettingsService;
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+    }
+
+    @Override
+    @Async("slackTaskExecutor")
+    public void sendActivityNotification(Post post) {
+        GroupSettings settings = groupSettingsService.getSettings();
+        if (!settings.isSlackEnabled()) {
+            log.debug("Slack notifications disabled — skipping");
+            return;
+        }
+        String webhookUrl = settings.getSlackWebhookUrl();
+        if (webhookUrl == null || webhookUrl.isBlank()) {
+            log.debug("No Slack webhook URL configured — skipping");
+            return;
+        }
+
+        String message = buildMessage(post);
+        try {
+            String payload = objectMapper.writeValueAsString(Map.of("text", message));
+            doPost(webhookUrl, payload);
+            log.info("Slack activity notification sent for post id={}", post.getId());
+        } catch (IOException e) {
+            log.error("Failed to send Slack activity notification for post id={}: {}", post.getId(), e.getMessage(), e);
+        }
+    }
+
+    void doPost(String webhookUrl, String payload) throws IOException {
+        Request.post(webhookUrl)
+            .bodyString(payload, ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8))
+            .execute()
+            .discardContent();
+    }
+
+    String buildMessage(Post post) {
+        User user = post.getUser();
+        String username = "Someone";
+        if (user != null) {
+            String first = user.getFirstName();
+            String last = user.getLastName();
+            if (first != null && !first.isBlank() && last != null && !last.isBlank()) {
+                username = first + " " + last;
+            } else if (first != null && !first.isBlank()) {
+                username = first;
+            } else if (user.getEmail() != null) {
+                username = user.getEmail();
+            }
+        }
+
+        String started = post.getStart() != null ? PostRenderer.formatDate(post.getStart()) : "unknown";
+        String finished = post.getFinish() != null ? PostRenderer.formatDate(post.getFinish()) : "unknown";
+        String postUrl = baseUrl + "/posts/" + (post.getId() != null ? post.getId() : "");
+
+        return username + " finished a post | Started: " + started + " | Finished: " + finished + " | View: " + postUrl;
+    }
+}

--- a/src/main/java/com/afitnerd/tnra/service/SlackNotificationServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/SlackNotificationServiceImpl.java
@@ -22,14 +22,17 @@ public class SlackNotificationServiceImpl implements SlackNotificationService {
     private static final Logger log = LoggerFactory.getLogger(SlackNotificationServiceImpl.class);
 
     private final GroupSettingsService groupSettingsService;
+    private final PostTokenService postTokenService;
     private final String baseUrl;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     public SlackNotificationServiceImpl(
         GroupSettingsService groupSettingsService,
+        PostTokenService postTokenService,
         @Value("${tnra.app.base-url:http://localhost:8080}") String baseUrl
     ) {
         this.groupSettingsService = groupSettingsService;
+        this.postTokenService = postTokenService;
         this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
     }
 
@@ -81,7 +84,9 @@ public class SlackNotificationServiceImpl implements SlackNotificationService {
 
         String started = post.getStart() != null ? PostRenderer.formatDate(post.getStart()) : "unknown";
         String finished = post.getFinish() != null ? PostRenderer.formatDate(post.getFinish()) : "unknown";
-        String postUrl = baseUrl + "/posts/" + (post.getId() != null ? post.getId() : "");
+        String postUrl = (post.getId() != null)
+            ? baseUrl + "/posts/" + postTokenService.encode(post.getId())
+            : baseUrl + "/posts/";
 
         return username + " finished a post | Started: " + started + " | Finished: " + finished + " | View: " + postUrl;
     }

--- a/src/main/java/com/afitnerd/tnra/service/SlackNotificationServiceImpl.java
+++ b/src/main/java/com/afitnerd/tnra/service/SlackNotificationServiceImpl.java
@@ -6,6 +6,7 @@ import com.afitnerd.tnra.model.User;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hc.client5.http.fluent.Request;
 import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.util.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -55,13 +56,15 @@ public class SlackNotificationServiceImpl implements SlackNotificationService {
             String payload = objectMapper.writeValueAsString(Map.of("text", message));
             doPost(webhookUrl, payload);
             log.info("Slack activity notification sent for post id={}", post.getId());
-        } catch (IOException e) {
+        } catch (Exception e) {
             log.error("Failed to send Slack activity notification for post id={}: {}", post.getId(), e.getMessage(), e);
         }
     }
 
     void doPost(String webhookUrl, String payload) throws IOException {
         Request.post(webhookUrl)
+            .connectTimeout(Timeout.ofSeconds(3))
+            .responseTimeout(Timeout.ofSeconds(5))
             .bodyString(payload, ContentType.APPLICATION_JSON.withCharset(StandardCharsets.UTF_8))
             .execute()
             .discardContent();
@@ -88,6 +91,11 @@ public class SlackNotificationServiceImpl implements SlackNotificationService {
             ? baseUrl + "/posts/" + postTokenService.encode(post.getId())
             : baseUrl + "/posts/";
 
-        return username + " finished a post | Started: " + started + " | Finished: " + finished + " | View: " + postUrl;
+        return escapeSlack(username) + " finished a post | Started: " + started + " | Finished: " + finished + " | View: " + postUrl;
+    }
+
+    private static String escapeSlack(String input) {
+        if (input == null) return "";
+        return input.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;");
     }
 }

--- a/src/main/java/com/afitnerd/tnra/vaadin/AdminView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/AdminView.java
@@ -2,15 +2,18 @@ package com.afitnerd.tnra.vaadin;
 
 import com.afitnerd.tnra.model.GoToGuyPair;
 import com.afitnerd.tnra.model.GoToGuySet;
+import com.afitnerd.tnra.model.GroupSettings;
 import com.afitnerd.tnra.model.StatDefinition;
 import com.afitnerd.tnra.model.User;
 import com.afitnerd.tnra.repository.PersonalStatDefinitionRepository;
 import com.afitnerd.tnra.repository.StatDefinitionRepository;
+import com.afitnerd.tnra.service.GroupSettingsService;
 import com.afitnerd.tnra.service.UserService;
 import com.afitnerd.tnra.vaadin.presenter.CallChainPresenter;
 import com.afitnerd.tnra.vaadin.presenter.VaadinAdminPresenter;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
+import com.vaadin.flow.component.checkbox.Checkbox;
 import com.vaadin.flow.component.combobox.ComboBox;
 import com.vaadin.flow.component.dependency.CssImport;
 import com.vaadin.flow.component.dialog.Dialog;
@@ -44,6 +47,7 @@ public class AdminView extends VerticalLayout {
     private final StatDefinitionRepository statDefinitionRepository;
     private final PersonalStatDefinitionRepository personalStatDefinitionRepository;
     private final UserService userService;
+    private final GroupSettingsService groupSettingsService;
     private GoToGuySet workingSet;
 
     public AdminView(
@@ -51,13 +55,15 @@ public class AdminView extends VerticalLayout {
         CallChainPresenter callChainPresenter,
         StatDefinitionRepository statDefinitionRepository,
         PersonalStatDefinitionRepository personalStatDefinitionRepository,
-        UserService userService
+        UserService userService,
+        GroupSettingsService groupSettingsService
     ) {
         this.vaadinAdminPresenter = vaadinAdminPresenter;
         this.callChainPresenter = callChainPresenter;
         this.statDefinitionRepository = statDefinitionRepository;
         this.personalStatDefinitionRepository = personalStatDefinitionRepository;
         this.userService = userService;
+        this.groupSettingsService = groupSettingsService;
 
         addClassName("admin-view");
         setSizeFull();
@@ -84,6 +90,7 @@ public class AdminView extends VerticalLayout {
         tabSheet.add("GTG", createGtgTabContent());
         tabSheet.add("Members", createMembersTabContent());
         tabSheet.add("Stats Config", createStatsConfigTabContent());
+        tabSheet.add("Integrations", createIntegrationsTabContent());
         tabSheet.add("Build Info", createBuildInfoTabContent());
 
         add(tabSheet);
@@ -455,6 +462,51 @@ public class AdminView extends VerticalLayout {
 
         dialog.add(formLayout, dialogButtons);
         dialog.open();
+    }
+
+    // ========================
+    // Integrations Tab
+    // ========================
+
+    VerticalLayout createIntegrationsTabContent() {
+        VerticalLayout content = new VerticalLayout();
+        content.setSizeFull();
+        content.setSpacing(true);
+        content.setPadding(true);
+
+        H3 header = new H3("Integrations");
+        header.addClassName("section-header");
+
+        Paragraph description = new Paragraph(
+            "Configure integrations. Activity notifications include username, start time, finish time, and a link to the post. No post content is sent."
+        );
+        description.addClassName("admin-subtitle");
+
+        H3 slackHeader = new H3("Slack");
+        slackHeader.addClassName("section-header");
+
+        GroupSettings settings = groupSettingsService.getSettings();
+
+        TextField webhookUrlField = new TextField("Incoming Webhook URL");
+        webhookUrlField.setPlaceholder("https://hooks.slack.com/services/...");
+        webhookUrlField.setWidth("100%");
+        webhookUrlField.setMaxWidth("600px");
+        webhookUrlField.setValue(settings.getSlackWebhookUrl() != null ? settings.getSlackWebhookUrl() : "");
+
+        Checkbox enabledCheckbox = new Checkbox("Enable Slack notifications");
+        enabledCheckbox.setValue(settings.isSlackEnabled());
+
+        Button saveBtn = new Button("Save", VaadinIcon.CHECK.create());
+        saveBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        saveBtn.addClickListener(e -> {
+            settings.setSlackWebhookUrl(webhookUrlField.getValue().isBlank() ? null : webhookUrlField.getValue().trim());
+            settings.setSlackEnabled(enabledCheckbox.getValue());
+            groupSettingsService.save(settings);
+            AppNotification.success("Slack settings saved");
+        });
+
+        content.add(header, description, slackHeader, webhookUrlField, enabledCheckbox, saveBtn);
+        return content;
     }
 
     // ========================

--- a/src/main/java/com/afitnerd/tnra/vaadin/AdminView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/AdminView.java
@@ -501,8 +501,12 @@ public class AdminView extends VerticalLayout {
         saveBtn.addClickListener(e -> {
             settings.setSlackWebhookUrl(webhookUrlField.getValue().isBlank() ? null : webhookUrlField.getValue().trim());
             settings.setSlackEnabled(enabledCheckbox.getValue());
-            groupSettingsService.save(settings);
-            AppNotification.success("Slack settings saved");
+            try {
+                groupSettingsService.save(settings);
+                AppNotification.success("Slack settings saved");
+            } catch (Exception ex) {
+                AppNotification.error("Failed to save Slack settings");
+            }
         });
 
         content.add(header, description, slackHeader, webhookUrlField, enabledCheckbox, saveBtn);

--- a/src/main/java/com/afitnerd/tnra/vaadin/AdminView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/AdminView.java
@@ -499,10 +499,16 @@ public class AdminView extends VerticalLayout {
         Button saveBtn = new Button("Save", VaadinIcon.CHECK.create());
         saveBtn.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
         saveBtn.addClickListener(e -> {
-            settings.setSlackWebhookUrl(webhookUrlField.getValue().isBlank() ? null : webhookUrlField.getValue().trim());
-            settings.setSlackEnabled(enabledCheckbox.getValue());
+            String url = webhookUrlField.getValue().isBlank() ? null : webhookUrlField.getValue().trim();
+            if (url != null && !url.startsWith("https://")) {
+                AppNotification.error("Webhook URL must use HTTPS");
+                return;
+            }
+            GroupSettings current = groupSettingsService.getSettings();
+            current.setSlackWebhookUrl(url);
+            current.setSlackEnabled(enabledCheckbox.getValue());
             try {
-                groupSettingsService.save(settings);
+                groupSettingsService.save(current);
                 AppNotification.success("Slack settings saved");
             } catch (Exception ex) {
                 AppNotification.error("Failed to save Slack settings");

--- a/src/main/java/com/afitnerd/tnra/vaadin/PostView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/PostView.java
@@ -162,23 +162,28 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver,
                 Optional<Post> deepLinkedPost = vaadinPostPresenter.getPostById(postId);
                 if (deepLinkedPost.isPresent()) {
                     Post post = deepLinkedPost.get();
-                    boolean isOwnPost = post.getUser().getId().equals(currentUser.getId());
+                    if (post.getUser() != null) {
+                        boolean isOwnPost = post.getUser().getId().equals(currentUser.getId());
 
-                    // Block access to other users' in-progress posts — fall through to default
-                    if (post.getState() == PostState.IN_PROGRESS && !isOwnPost) {
-                        log.warn("Deep link denied: user {} attempted to view in-progress post {} owned by user {}",
-                            currentUser.getId(), postId, post.getUser().getId());
-                        pendingNotification = "Unable to load post.";
-                    } else {
-                        currentPost = post;
-                        selectedUser = post.getUser();
-                        // Own in-progress post: show in-progress view
-                        // All other cases (completed posts, other users' completed posts): show completed view
-                        showingCompletedPosts = !(post.getState() == PostState.IN_PROGRESS && isOwnPost);
-                        if (showingCompletedPosts) {
-                            loadCurrentPage();
+                        // Block access to other users' in-progress posts — fall through to default
+                        if (post.getState() == PostState.IN_PROGRESS && !isOwnPost) {
+                            log.warn("Deep link denied: user {} attempted to view in-progress post {} owned by user {}",
+                                currentUser.getId(), postId, post.getUser().getId());
+                            pendingNotification = "Unable to load post.";
+                        } else {
+                            currentPost = post;
+                            selectedUser = post.getUser();
+                            // Own in-progress post: show in-progress view
+                            // All other cases (completed posts, other users' completed posts): show completed view
+                            showingCompletedPosts = !(post.getState() == PostState.IN_PROGRESS && isOwnPost);
+                            if (showingCompletedPosts) {
+                                loadCurrentPage();
+                            }
+                            return;
                         }
-                        return;
+                    } else {
+                        log.warn("Deep link failed: post {} has no owner", postId);
+                        pendingNotification = "Unable to load post.";
                     }
                 } else {
                     log.warn("Deep link failed: post not found for token");

--- a/src/main/java/com/afitnerd/tnra/vaadin/PostView.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/PostView.java
@@ -3,6 +3,7 @@ package com.afitnerd.tnra.vaadin;
 import com.afitnerd.tnra.model.Post;
 import com.afitnerd.tnra.model.PostState;
 import com.afitnerd.tnra.model.User;
+import com.afitnerd.tnra.service.PostTokenService;
 import com.afitnerd.tnra.vaadin.presenter.VaadinPostPresenter;
 import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
@@ -41,15 +42,16 @@ import java.util.Optional;
 @Route(value = "posts", layout = MainLayout.class)
 @PermitAll
 @CssImport("./styles/post-view.css")
-public class PostView extends VerticalLayout implements AfterNavigationObserver, HasUrlParameter<Long> {
+public class PostView extends VerticalLayout implements AfterNavigationObserver, HasUrlParameter<String> {
 
     private static final Logger log = LoggerFactory.getLogger(PostView.class);
 
     private final VaadinPostPresenter vaadinPostPresenter;
+    private final PostTokenService postTokenService;
     private User currentUser;
     private User selectedUser;
     private Post currentPost;
-    private Long deepLinkPostId;
+    private String deepLinkToken;
     private String pendingNotification;
     
     // Server-side pagination fields
@@ -102,16 +104,17 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver,
     // is the true param for nested properties needed?
     private Binder<Post> postBinder = new Binder<>(Post.class, true);
 
-    public PostView(VaadinPostPresenter vaadinPostPresenter) {
+    public PostView(VaadinPostPresenter vaadinPostPresenter, PostTokenService postTokenService) {
         this.vaadinPostPresenter = vaadinPostPresenter;
+        this.postTokenService = postTokenService;
 
         setSizeFull();
         addClassName("post-view");
     }
 
     @Override
-    public void setParameter(BeforeEvent event, @OptionalParameter Long postId) {
-        this.deepLinkPostId = postId;
+    public void setParameter(BeforeEvent event, @OptionalParameter String token) {
+        this.deepLinkToken = token;
     }
 
     @Override
@@ -126,7 +129,7 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver,
             loadPostData();
             updateReadOnlyState();
             // For deep-linked completed posts, also select in the dropdown
-            if (showingCompletedPosts && deepLinkPostId != null && postSelector != null) {
+            if (showingCompletedPosts && deepLinkToken != null && postSelector != null) {
                 postSelector.setValue(currentPost);
             }
         }
@@ -146,32 +149,41 @@ public class PostView extends VerticalLayout implements AfterNavigationObserver,
         currentUser = vaadinPostPresenter.initializeUser();
         selectedUser = currentUser; // Default to current authenticated user
 
-        // Deep link: if a postId was provided via URL parameter, load that specific post
-        if (deepLinkPostId != null) {
-            Optional<Post> deepLinkedPost = vaadinPostPresenter.getPostById(deepLinkPostId);
-            if (deepLinkedPost.isPresent()) {
-                Post post = deepLinkedPost.get();
-                boolean isOwnPost = post.getUser().getId().equals(currentUser.getId());
-
-                // Block access to other users' in-progress posts — fall through to default
-                if (post.getState() == PostState.IN_PROGRESS && !isOwnPost) {
-                    log.warn("Deep link denied: user {} attempted to view in-progress post {} owned by user {}",
-                        currentUser.getId(), deepLinkPostId, post.getUser().getId());
-                    pendingNotification = "Unable to load post.";
-                } else {
-                    currentPost = post;
-                    selectedUser = post.getUser();
-                    // Own in-progress post: show in-progress view
-                    // All other cases (completed posts, other users' completed posts): show completed view
-                    showingCompletedPosts = !(post.getState() == PostState.IN_PROGRESS && isOwnPost);
-                    if (showingCompletedPosts) {
-                        loadCurrentPage();
-                    }
-                    return;
-                }
-            } else {
-                log.warn("Deep link failed: post {} not found", deepLinkPostId);
+        // Deep link: if a token was provided via URL parameter, decode and load that specific post
+        if (deepLinkToken != null) {
+            Long postId = null;
+            try {
+                postId = postTokenService.decode(deepLinkToken);
+            } catch (IllegalArgumentException e) {
+                log.warn("Deep link failed: invalid or tampered post token");
                 pendingNotification = "Unable to load post.";
+            }
+            if (postId != null) {
+                Optional<Post> deepLinkedPost = vaadinPostPresenter.getPostById(postId);
+                if (deepLinkedPost.isPresent()) {
+                    Post post = deepLinkedPost.get();
+                    boolean isOwnPost = post.getUser().getId().equals(currentUser.getId());
+
+                    // Block access to other users' in-progress posts — fall through to default
+                    if (post.getState() == PostState.IN_PROGRESS && !isOwnPost) {
+                        log.warn("Deep link denied: user {} attempted to view in-progress post {} owned by user {}",
+                            currentUser.getId(), postId, post.getUser().getId());
+                        pendingNotification = "Unable to load post.";
+                    } else {
+                        currentPost = post;
+                        selectedUser = post.getUser();
+                        // Own in-progress post: show in-progress view
+                        // All other cases (completed posts, other users' completed posts): show completed view
+                        showingCompletedPosts = !(post.getState() == PostState.IN_PROGRESS && isOwnPost);
+                        if (showingCompletedPosts) {
+                            loadCurrentPage();
+                        }
+                        return;
+                    }
+                } else {
+                    log.warn("Deep link failed: post not found for token");
+                    pendingNotification = "Unable to load post.";
+                }
             }
         }
 

--- a/src/main/java/com/afitnerd/tnra/vaadin/presenter/VaadinPostPresenterImpl.java
+++ b/src/main/java/com/afitnerd/tnra/vaadin/presenter/VaadinPostPresenterImpl.java
@@ -10,6 +10,7 @@ import com.afitnerd.tnra.repository.StatDefinitionRepository;
 import com.afitnerd.tnra.service.EMailService;
 import com.afitnerd.tnra.service.OidcUserService;
 import com.afitnerd.tnra.service.PostService;
+import com.afitnerd.tnra.service.SlackNotificationService;
 import com.afitnerd.tnra.service.UserService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
@@ -26,6 +27,7 @@ public class VaadinPostPresenterImpl implements VaadinPostPresenter {
     private final OidcUserService oidcUserService;
     private final PostService postService;
     private final EMailService eMailService;
+    private final SlackNotificationService slackNotificationService;
     private final PostRepository postRepository;
     private final StatDefinitionRepository statDefinitionRepository;
     private final PersonalStatDefinitionRepository personalStatDefinitionRepository;
@@ -36,6 +38,7 @@ public class VaadinPostPresenterImpl implements VaadinPostPresenter {
     public VaadinPostPresenterImpl(
         OidcUserService oidcUserService, UserService userService,
         PostService postService, EMailService eMailService,
+        SlackNotificationService slackNotificationService,
         PostRepository postRepository,
         StatDefinitionRepository statDefinitionRepository,
         PersonalStatDefinitionRepository personalStatDefinitionRepository
@@ -44,6 +47,7 @@ public class VaadinPostPresenterImpl implements VaadinPostPresenter {
         this.userService = userService;
         this.postService = postService;
         this.eMailService = eMailService;
+        this.slackNotificationService = slackNotificationService;
         this.postRepository = postRepository;
         this.statDefinitionRepository = statDefinitionRepository;
         this.personalStatDefinitionRepository = personalStatDefinitionRepository;
@@ -55,6 +59,7 @@ public class VaadinPostPresenterImpl implements VaadinPostPresenter {
         if (emailServiceEnabled) {
             eMailService.sendMailToAll(post);
         }
+        slackNotificationService.sendActivityNotification(post);
         return post;
     }
 

--- a/src/main/resources/META-INF/resources/frontend/styles/stats-view.css
+++ b/src/main/resources/META-INF/resources/frontend/styles/stats-view.css
@@ -115,21 +115,24 @@
 .readonly-card {
     pointer-events: none;
     transition: opacity 0.3s ease;
-    opacity: 0.7;
+    opacity: 0.9;
 }
 
 .readonly-input {
-    background-color: var(--tnra-readonly-bg) !important;
-    color: var(--tnra-readonly-text) !important;
+    --lumo-body-text-color: var(--tnra-text-secondary);
+    --lumo-disabled-text-color: var(--tnra-text-secondary);
     border-color: var(--tnra-readonly-border) !important;
     cursor: not-allowed;
-    opacity: 0.6;
     transition: opacity 0.3s ease;
+}
+
+.readonly-input::part(input-field) {
+    background-color: var(--tnra-readonly-bg);
+    cursor: not-allowed;
 }
 
 .readonly-input input {
     background-color: var(--tnra-readonly-bg) !important;
-    color: var(--tnra-readonly-text) !important;
     cursor: not-allowed;
 }
 

--- a/src/main/resources/db/migration/V11__group_settings.sql
+++ b/src/main/resources/db/migration/V11__group_settings.sql
@@ -1,0 +1,8 @@
+CREATE TABLE group_settings (
+    id               BIGINT   NOT NULL AUTO_INCREMENT,
+    slack_webhook_url TEXT,
+    slack_enabled    BOOLEAN  NOT NULL DEFAULT FALSE,
+    created_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at       DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id)
+);

--- a/src/test/java/com/afitnerd/tnra/service/ActivityNotificationRendererTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/ActivityNotificationRendererTest.java
@@ -77,6 +77,16 @@ class ActivityNotificationRendererTest {
         assertTrue(html.contains("&lt;script&gt;"));
     }
 
+    @Test
+    void constructorStripsTrailingSlash() {
+        ActivityNotificationRenderer r = new ActivityNotificationRenderer(postTokenService, "https://tnra.example.com/");
+        when(postTokenService.encode(1L)).thenReturn("tok1");
+        Post post = createPost("Jane", "Doe");
+        post.setId(1L);
+        String html = r.render(post);
+        assertTrue(html.contains("https://tnra.example.com/posts/tok1"));
+    }
+
     private Post createPost(String firstName, String lastName) {
         User user = new User(firstName, lastName, "test@example.com");
         Post post = new Post();

--- a/src/test/java/com/afitnerd/tnra/service/ActivityNotificationRendererTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/ActivityNotificationRendererTest.java
@@ -2,17 +2,26 @@ package com.afitnerd.tnra.service;
 
 import com.afitnerd.tnra.model.Post;
 import com.afitnerd.tnra.model.User;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class ActivityNotificationRendererTest {
 
-    private final ActivityNotificationRenderer renderer =
-        new ActivityNotificationRenderer("https://tnra.example.com");
+    private PostTokenService postTokenService;
+    private ActivityNotificationRenderer renderer;
+
+    @BeforeEach
+    void setUp() {
+        postTokenService = mock(PostTokenService.class);
+        renderer = new ActivityNotificationRenderer(postTokenService, "https://tnra.example.com");
+    }
 
     @Test
     void renderIncludesUserFirstName() {
@@ -52,10 +61,11 @@ class ActivityNotificationRendererTest {
 
     @Test
     void renderIncludesDeepLinkToPost() {
+        when(postTokenService.encode(42L)).thenReturn("token42");
         Post post = createPost("John", "Doe");
         post.setId(42L);
         String html = renderer.render(post);
-        assertTrue(html.contains("https://tnra.example.com/posts/42"));
+        assertTrue(html.contains("https://tnra.example.com/posts/token42"));
         assertTrue(html.contains("View post</a>"));
     }
 

--- a/src/test/java/com/afitnerd/tnra/service/GroupSettingsServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/GroupSettingsServiceImplTest.java
@@ -47,6 +47,13 @@ class GroupSettingsServiceImplTest {
     }
 
     @Test
+    void newGroupSettings_hasNonNullTimestamps() {
+        GroupSettings settings = new GroupSettings();
+        assertNotNull(settings.getCreatedAt());
+        assertNotNull(settings.getUpdatedAt());
+    }
+
+    @Test
     void save_delegatesToRepository() {
         GroupSettings settings = new GroupSettings();
         when(repository.save(settings)).thenReturn(settings);

--- a/src/test/java/com/afitnerd/tnra/service/GroupSettingsServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/GroupSettingsServiceImplTest.java
@@ -1,0 +1,59 @@
+package com.afitnerd.tnra.service;
+
+import com.afitnerd.tnra.model.GroupSettings;
+import com.afitnerd.tnra.repository.GroupSettingsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class GroupSettingsServiceImplTest {
+
+    private GroupSettingsRepository repository;
+    private GroupSettingsServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(GroupSettingsRepository.class);
+        service = new GroupSettingsServiceImpl(repository);
+    }
+
+    @Test
+    void getSettings_returnsExistingRow() {
+        GroupSettings existing = new GroupSettings();
+        existing.setSlackWebhookUrl("https://hooks.slack.com/test");
+        existing.setSlackEnabled(true);
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.of(existing));
+
+        GroupSettings result = service.getSettings();
+
+        assertSame(existing, result);
+        assertEquals("https://hooks.slack.com/test", result.getSlackWebhookUrl());
+        assertTrue(result.isSlackEnabled());
+    }
+
+    @Test
+    void getSettings_returnsNewInstanceWhenNoRowExists() {
+        when(repository.findFirstByOrderByIdAsc()).thenReturn(Optional.empty());
+
+        GroupSettings result = service.getSettings();
+
+        assertNotNull(result);
+        assertNull(result.getSlackWebhookUrl());
+        assertFalse(result.isSlackEnabled());
+    }
+
+    @Test
+    void save_delegatesToRepository() {
+        GroupSettings settings = new GroupSettings();
+        when(repository.save(settings)).thenReturn(settings);
+
+        GroupSettings result = service.save(settings);
+
+        assertSame(settings, result);
+        verify(repository).save(settings);
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/service/PostTokenServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/PostTokenServiceImplTest.java
@@ -1,0 +1,70 @@
+package com.afitnerd.tnra.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class PostTokenServiceImplTest {
+
+    private EncryptionService encryptionService;
+    private PostTokenServiceImpl postTokenService;
+
+    @BeforeEach
+    void setUp() {
+        encryptionService = mock(EncryptionService.class);
+        postTokenService = new PostTokenServiceImpl(encryptionService);
+    }
+
+    @Test
+    void encode_stripsPaddingEquals() {
+        when(encryptionService.encrypt("42")).thenReturn("ENC:dGVzdA==");
+        String token = postTokenService.encode(42L);
+        assertEquals("dGVzdA", token, "encode should strip '=' padding");
+    }
+
+    @Test
+    void encode_replacesPlusWithDashAndSlashWithUnderscore() {
+        when(encryptionService.encrypt("42")).thenReturn("ENC:a+b/c+d/");
+        String token = postTokenService.encode(42L);
+        assertEquals("a-b_c-d_", token, "encode should replace '+' with '-' and '/' with '_'");
+    }
+
+    @Test
+    void decode_restoresPaddingAndDelegates() {
+        when(encryptionService.decrypt("ENC:dGVzdA==")).thenReturn("42");
+        Long result = postTokenService.decode("dGVzdA");
+        assertEquals(42L, result, "decode should re-pad and return parsed Long");
+    }
+
+    @Test
+    void decode_reversesUrlSafeSubstitutions() {
+        when(encryptionService.decrypt("ENC:a+b/c+d/")).thenReturn("1");
+        Long result = postTokenService.decode("a-b_c-d_");
+        assertEquals(1L, result, "decode should replace '-' with '+' and '_' with '/'");
+    }
+
+    @Test
+    void decode_throwsIllegalArgumentExceptionWhenDecryptThrows() {
+        when(encryptionService.decrypt(any())).thenThrow(new IllegalStateException("bad crypto"));
+        assertThrows(IllegalArgumentException.class, () -> postTokenService.decode("sometoken"),
+            "decode should wrap decrypt exceptions in IllegalArgumentException");
+    }
+
+    @Test
+    void decode_throwsIllegalArgumentExceptionWhenDecryptedIsNotANumber() {
+        when(encryptionService.decrypt(any())).thenReturn("not-a-number");
+        assertThrows(IllegalArgumentException.class, () -> postTokenService.decode("sometoken"),
+            "decode should throw when decrypted string is not a valid Long");
+    }
+
+    @Test
+    void encode_producesOnlyUrlSafeCharacters() {
+        when(encryptionService.encrypt("42")).thenReturn("ENC:a+b/c+d/==");
+        String token = postTokenService.encode(42L);
+        assertTrue(token.matches("[A-Za-z0-9_-]*"),
+            "encode should produce only URL-safe characters: got '" + token + "'");
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/service/SlackNotificationServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/SlackNotificationServiceImplTest.java
@@ -106,6 +106,15 @@ class SlackNotificationServiceImplTest {
     }
 
     @Test
+    void buildMessage_escapesSlackMrkdwnInUserName() {
+        Post post = createPost("<attacker>", "User", 5L);
+        when(postTokenService.encode(5L)).thenReturn("tok5");
+        String msg = service.buildMessage(post);
+        assertFalse(msg.contains("<attacker>"), "Raw angle brackets should be escaped");
+        assertTrue(msg.contains("&lt;attacker&gt;"));
+    }
+
+    @Test
     void buildMessage_usesSomeoneWhenUserHasAllNullFields() {
         User user = new User(null, null, null);
         Post post = new Post();

--- a/src/test/java/com/afitnerd/tnra/service/SlackNotificationServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/SlackNotificationServiceImplTest.java
@@ -16,23 +16,28 @@ import static org.mockito.Mockito.*;
 class SlackNotificationServiceImplTest {
 
     private GroupSettingsService groupSettingsService;
+    private PostTokenService postTokenService;
     private SlackNotificationServiceImpl service;
 
     @BeforeEach
     void setUp() {
         groupSettingsService = mock(GroupSettingsService.class);
-        service = new SlackNotificationServiceImpl(groupSettingsService, "https://tnra.example.com");
+        postTokenService = mock(PostTokenService.class);
+        // Default stub: return a placeholder token for any Long ID
+        when(postTokenService.encode(anyLong())).thenReturn("token");
+        service = new SlackNotificationServiceImpl(groupSettingsService, postTokenService, "https://tnra.example.com");
     }
 
     // --- constructor ---
 
     @Test
     void constructorStripsTrailingSlash() {
-        SlackNotificationServiceImpl svc = new SlackNotificationServiceImpl(groupSettingsService, "https://example.com/");
+        when(postTokenService.encode(1L)).thenReturn("token1");
+        SlackNotificationServiceImpl svc = new SlackNotificationServiceImpl(groupSettingsService, postTokenService, "https://example.com/");
         Post post = createPost("Alice", "Smith", 1L);
         String msg = svc.buildMessage(post);
         // URL in message should not have double slash
-        assertTrue(msg.contains("https://example.com/posts/1"));
+        assertTrue(msg.contains("https://example.com/posts/token1"));
         assertFalse(msg.contains("//posts/"));
     }
 
@@ -40,6 +45,7 @@ class SlackNotificationServiceImplTest {
 
     @Test
     void buildMessage_includesFullNameStartFinishAndLink() {
+        when(postTokenService.encode(99L)).thenReturn("token99");
         Post post = createPost("Alice", "Smith", 99L);
         post.setStart(new Date(0));
         post.setFinish(new Date(60_000));
@@ -50,7 +56,7 @@ class SlackNotificationServiceImplTest {
         assertTrue(msg.contains("finished a post"));
         assertTrue(msg.contains("Started:"));
         assertTrue(msg.contains("Finished:"));
-        assertTrue(msg.contains("https://tnra.example.com/posts/99"));
+        assertTrue(msg.contains("https://tnra.example.com/posts/token99"));
     }
 
     @Test
@@ -152,6 +158,7 @@ class SlackNotificationServiceImplTest {
         settings.setSlackEnabled(true);
         settings.setSlackWebhookUrl("https://hooks.slack.com/test");
         when(groupSettingsService.getSettings()).thenReturn(settings);
+        when(postTokenService.encode(10L)).thenReturn("token10");
 
         SlackNotificationServiceImpl spy = spy(service);
         doNothing().when(spy).doPost(anyString(), anyString());

--- a/src/test/java/com/afitnerd/tnra/service/SlackNotificationServiceImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/service/SlackNotificationServiceImplTest.java
@@ -1,0 +1,185 @@
+package com.afitnerd.tnra.service;
+
+import com.afitnerd.tnra.model.GroupSettings;
+import com.afitnerd.tnra.model.Post;
+import com.afitnerd.tnra.model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.Date;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class SlackNotificationServiceImplTest {
+
+    private GroupSettingsService groupSettingsService;
+    private SlackNotificationServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        groupSettingsService = mock(GroupSettingsService.class);
+        service = new SlackNotificationServiceImpl(groupSettingsService, "https://tnra.example.com");
+    }
+
+    // --- constructor ---
+
+    @Test
+    void constructorStripsTrailingSlash() {
+        SlackNotificationServiceImpl svc = new SlackNotificationServiceImpl(groupSettingsService, "https://example.com/");
+        Post post = createPost("Alice", "Smith", 1L);
+        String msg = svc.buildMessage(post);
+        // URL in message should not have double slash
+        assertTrue(msg.contains("https://example.com/posts/1"));
+        assertFalse(msg.contains("//posts/"));
+    }
+
+    // --- buildMessage ---
+
+    @Test
+    void buildMessage_includesFullNameStartFinishAndLink() {
+        Post post = createPost("Alice", "Smith", 99L);
+        post.setStart(new Date(0));
+        post.setFinish(new Date(60_000));
+
+        String msg = service.buildMessage(post);
+
+        assertTrue(msg.contains("Alice Smith"));
+        assertTrue(msg.contains("finished a post"));
+        assertTrue(msg.contains("Started:"));
+        assertTrue(msg.contains("Finished:"));
+        assertTrue(msg.contains("https://tnra.example.com/posts/99"));
+    }
+
+    @Test
+    void buildMessage_usesFirstNameOnlyWhenLastNameNull() {
+        Post post = createPost("Bob", null, 1L);
+        String msg = service.buildMessage(post);
+        assertTrue(msg.startsWith("Bob "));
+    }
+
+    @Test
+    void buildMessage_usesEmailWhenNamesNull() {
+        User user = new User(null, null, "anon@example.com");
+        Post post = new Post();
+        post.setUser(user);
+        post.setId(2L);
+
+        String msg = service.buildMessage(post);
+        assertTrue(msg.contains("anon@example.com"));
+    }
+
+    @Test
+    void buildMessage_usesSomeoneWhenUserNull() {
+        Post post = new Post();
+        post.setUser(null);
+        post.setId(3L);
+
+        String msg = service.buildMessage(post);
+        assertTrue(msg.startsWith("Someone "));
+    }
+
+    @Test
+    void buildMessage_handlesNullStartAndFinish() {
+        Post post = createPost("Carol", "Jones", 5L);
+        post.setStart(null);
+        post.setFinish(null);
+
+        String msg = service.buildMessage(post);
+        assertTrue(msg.contains("Started: unknown"));
+        assertTrue(msg.contains("Finished: unknown"));
+    }
+
+    @Test
+    void buildMessage_handlesNullPostId() {
+        Post post = createPost("Dave", "Kim", null);
+        String msg = service.buildMessage(post);
+        assertTrue(msg.contains("https://tnra.example.com/posts/"));
+    }
+
+    @Test
+    void buildMessage_usesSomeoneWhenUserHasAllNullFields() {
+        User user = new User(null, null, null);
+        Post post = new Post();
+        post.setUser(user);
+        post.setId(7L);
+
+        String msg = service.buildMessage(post);
+        assertTrue(msg.startsWith("Someone "));
+    }
+
+    // --- sendActivityNotification (early-exit paths, no real HTTP) ---
+
+    @Test
+    void sendActivityNotification_skipsWhenDisabled() {
+        GroupSettings settings = new GroupSettings();
+        settings.setSlackEnabled(false);
+        settings.setSlackWebhookUrl("https://hooks.slack.com/test");
+        when(groupSettingsService.getSettings()).thenReturn(settings);
+
+        // Should not throw; no HTTP call made (would fail immediately if attempted with this URL)
+        service.sendActivityNotification(createPost("Test", "User", 1L));
+        verify(groupSettingsService, times(1)).getSettings();
+    }
+
+    @Test
+    void sendActivityNotification_skipsWhenWebhookUrlNull() {
+        GroupSettings settings = new GroupSettings();
+        settings.setSlackEnabled(true);
+        settings.setSlackWebhookUrl(null);
+        when(groupSettingsService.getSettings()).thenReturn(settings);
+
+        service.sendActivityNotification(createPost("Test", "User", 1L));
+        verify(groupSettingsService, times(1)).getSettings();
+    }
+
+    @Test
+    void sendActivityNotification_skipsWhenWebhookUrlBlank() {
+        GroupSettings settings = new GroupSettings();
+        settings.setSlackEnabled(true);
+        settings.setSlackWebhookUrl("   ");
+        when(groupSettingsService.getSettings()).thenReturn(settings);
+
+        service.sendActivityNotification(createPost("Test", "User", 1L));
+        verify(groupSettingsService, times(1)).getSettings();
+    }
+
+    @Test
+    void sendActivityNotification_postsWhenEnabledAndUrlSet() throws Exception {
+        GroupSettings settings = new GroupSettings();
+        settings.setSlackEnabled(true);
+        settings.setSlackWebhookUrl("https://hooks.slack.com/test");
+        when(groupSettingsService.getSettings()).thenReturn(settings);
+
+        SlackNotificationServiceImpl spy = spy(service);
+        doNothing().when(spy).doPost(anyString(), anyString());
+
+        spy.sendActivityNotification(createPost("Alice", "Smith", 10L));
+
+        verify(spy).doPost(eq("https://hooks.slack.com/test"), contains("Alice Smith"));
+    }
+
+    @Test
+    void sendActivityNotification_logsErrorOnIOException() throws Exception {
+        GroupSettings settings = new GroupSettings();
+        settings.setSlackEnabled(true);
+        settings.setSlackWebhookUrl("https://hooks.slack.com/test");
+        when(groupSettingsService.getSettings()).thenReturn(settings);
+
+        SlackNotificationServiceImpl spy = spy(service);
+        doThrow(new IOException("timeout")).when(spy).doPost(anyString(), anyString());
+
+        // should not throw — error is logged
+        assertDoesNotThrow(() -> spy.sendActivityNotification(createPost("Bob", "Jones", 11L)));
+    }
+
+    private Post createPost(String firstName, String lastName, Long id) {
+        User user = new User(firstName, lastName, "test@example.com");
+        Post post = new Post();
+        post.setUser(user);
+        post.setId(id);
+        return post;
+    }
+}

--- a/src/test/java/com/afitnerd/tnra/vaadin/AdminViewDialogTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/AdminViewDialogTest.java
@@ -5,8 +5,10 @@ import com.afitnerd.tnra.model.GoToGuySet;
 import com.afitnerd.tnra.model.PersonalStatDefinition;
 import com.afitnerd.tnra.model.StatDefinition;
 import com.afitnerd.tnra.model.User;
+import com.afitnerd.tnra.model.GroupSettings;
 import com.afitnerd.tnra.repository.PersonalStatDefinitionRepository;
 import com.afitnerd.tnra.repository.StatDefinitionRepository;
+import com.afitnerd.tnra.service.GroupSettingsService;
 import com.afitnerd.tnra.service.UserService;
 import com.afitnerd.tnra.vaadin.presenter.CallChainPresenter;
 import com.afitnerd.tnra.vaadin.presenter.VaadinAdminPresenter;
@@ -55,6 +57,7 @@ class AdminViewDialogTest {
     private StatDefinitionRepository statDefinitionRepository;
     private PersonalStatDefinitionRepository personalStatDefinitionRepository;
     private UserService userService;
+    private GroupSettingsService groupSettingsService;
     private UI ui;
 
     @BeforeEach
@@ -64,6 +67,7 @@ class AdminViewDialogTest {
         statDefinitionRepository = mock(StatDefinitionRepository.class);
         personalStatDefinitionRepository = mock(PersonalStatDefinitionRepository.class);
         userService = mock(UserService.class);
+        groupSettingsService = mock(GroupSettingsService.class);
 
         ui = new UI();
         VaadinSession session = mock(VaadinSession.class, Mockito.RETURNS_DEEP_STUBS);
@@ -83,6 +87,7 @@ class AdminViewDialogTest {
         lenient().when(userService.getAllActiveUsers()).thenReturn(List.of());
         lenient().when(userService.getAllUsers()).thenReturn(List.of());
         lenient().when(userService.getCurrentUser()).thenReturn(null);
+        lenient().when(groupSettingsService.getSettings()).thenReturn(new GroupSettings());
     }
 
     @AfterEach
@@ -99,7 +104,7 @@ class AdminViewDialogTest {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
         when(userService.getUserByEmail("newmember@example.com")).thenReturn(null);
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         Grid<User> membersGrid = new Grid<>();
@@ -119,7 +124,7 @@ class AdminViewDialogTest {
     void inviteDialogInvalidEmailDoesNotCallInviteUser() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         Grid<User> membersGrid = new Grid<>();
@@ -138,7 +143,7 @@ class AdminViewDialogTest {
     void inviteDialogEmptyEmailDoesNotCallInviteUser() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         Grid<User> membersGrid = new Grid<>();
@@ -164,7 +169,7 @@ class AdminViewDialogTest {
 
         when(userService.getUserByEmail("existing@example.com")).thenReturn(existingUser);
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         Grid<User> membersGrid = new Grid<>();
@@ -190,7 +195,7 @@ class AdminViewDialogTest {
         when(statDefinitionRepository.findGlobalActiveOrderByDisplayOrderAsc()).thenReturn(new ArrayList<>());
         when(personalStatDefinitionRepository.findByArchivedFalse()).thenReturn(List.of());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         VerticalLayout statsList = new VerticalLayout();
@@ -218,7 +223,7 @@ class AdminViewDialogTest {
         when(statDefinitionRepository.findGlobalAllOrderByDisplayOrderAsc()).thenReturn(List.of(existing));
         when(personalStatDefinitionRepository.findByArchivedFalse()).thenReturn(List.of());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         VerticalLayout statsList = new VerticalLayout();
@@ -243,7 +248,7 @@ class AdminViewDialogTest {
         PersonalStatDefinition existing = new PersonalStatDefinition("journaling", "Journaling", null, 0, null);
         when(personalStatDefinitionRepository.findByArchivedFalse()).thenReturn(List.of(existing));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         VerticalLayout statsList = new VerticalLayout();
@@ -266,7 +271,7 @@ class AdminViewDialogTest {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
         when(statDefinitionRepository.findGlobalAllOrderByDisplayOrderAsc()).thenReturn(List.of());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         VerticalLayout statsList = new VerticalLayout();
@@ -291,7 +296,7 @@ class AdminViewDialogTest {
         when(statDefinitionRepository.findGlobalActiveOrderByDisplayOrderAsc()).thenReturn(new ArrayList<>());
         when(personalStatDefinitionRepository.findByArchivedFalse()).thenReturn(List.of());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         VerticalLayout statsList = new VerticalLayout();
@@ -335,7 +340,7 @@ class AdminViewDialogTest {
         newSet.setGoToGuyPairs(new ArrayList<>());
         when(callChainPresenter.createNewGoToGuySet(anyList())).thenReturn(newSet);
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         // Create a new set first so workingSet is populated
@@ -384,7 +389,7 @@ class AdminViewDialogTest {
         when(callChainPresenter.addPairToSet(any(GoToGuySet.class), any(GoToGuyPair.class))).thenReturn(updatedSet);
         when(callChainPresenter.validatePair(eq(alice), eq(bob), anyList())).thenReturn(true);
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         // Create new set
@@ -425,7 +430,7 @@ class AdminViewDialogTest {
         when(callChainPresenter.createNewGoToGuySet(anyList())).thenReturn(newSet);
         when(callChainPresenter.validatePair(eq(alice), eq(alice), anyList())).thenReturn(false);
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         // Create new set
@@ -476,7 +481,7 @@ class AdminViewDialogTest {
         newSet.setGoToGuyPairs(new ArrayList<>());
         when(callChainPresenter.createNewGoToGuySet(anyList())).thenReturn(newSet);
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         // Create new set

--- a/src/test/java/com/afitnerd/tnra/vaadin/AdminViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/AdminViewTest.java
@@ -29,6 +29,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.lang.reflect.Method;
+import com.vaadin.flow.component.textfield.TextField;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -38,6 +39,7 @@ import org.mockito.MockedStatic;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -45,6 +47,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyString;
+import org.mockito.ArgumentCaptor;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
@@ -945,6 +948,49 @@ class AdminViewTest {
             saveBtn.click();
             mocked.verify(() -> AppNotification.error(anyString()));
         }
+    }
+
+    @Test
+    void integrationsTabSaveButtonRejectsNonHttpsWebhookUrl() {
+        when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(sampleSet());
+        GroupSettings settings = new GroupSettings();
+        when(groupSettingsService.getSettings()).thenReturn(settings);
+
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
+        ui.add(view);
+
+        try (org.mockito.MockedStatic<AppNotification> mocked = mockStatic(AppNotification.class)) {
+            mocked.when(() -> AppNotification.error(anyString())).thenAnswer(inv -> null);
+            VerticalLayout integrationsTab = view.createIntegrationsTabContent();
+            TextField webhookField = firstComponent(integrationsTab, TextField.class, f -> true);
+            webhookField.setValue("http://evil.example.com/hook");
+            Button saveBtn = firstComponent(integrationsTab, Button.class, b -> "Save".equals(b.getText()));
+            saveBtn.click();
+            mocked.verify(() -> AppNotification.error(anyString()));
+            verify(groupSettingsService, never()).save(any(GroupSettings.class));
+        }
+    }
+
+    @Test
+    void integrationsTabSaveButtonSetsNullWebhookUrlWhenBlank() {
+        when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(sampleSet());
+        GroupSettings settings = new GroupSettings();
+        settings.setSlackWebhookUrl("https://hooks.slack.com/existing");
+        when(groupSettingsService.getSettings()).thenReturn(settings);
+        when(groupSettingsService.save(any(GroupSettings.class))).thenReturn(settings);
+
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
+        ui.add(view);
+
+        VerticalLayout integrationsTab = view.createIntegrationsTabContent();
+        TextField webhookField = firstComponent(integrationsTab, TextField.class, f -> true);
+        webhookField.setValue("");
+        Button saveBtn = firstComponent(integrationsTab, Button.class, b -> "Save".equals(b.getText()));
+        saveBtn.click();
+
+        ArgumentCaptor<GroupSettings> captor = ArgumentCaptor.forClass(GroupSettings.class);
+        verify(groupSettingsService).save(captor.capture());
+        assertNull(captor.getValue().getSlackWebhookUrl());
     }
 
     private <T extends Component> boolean anyComponent(Component root, Class<T> type, Predicate<T> predicate) {

--- a/src/test/java/com/afitnerd/tnra/vaadin/AdminViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/AdminViewTest.java
@@ -928,6 +928,25 @@ class AdminViewTest {
         verify(groupSettingsService).save(any(GroupSettings.class));
     }
 
+    @Test
+    void integrationsTabSaveButtonShowsErrorNotificationOnSaveFailure() {
+        when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(sampleSet());
+        GroupSettings settings = new GroupSettings();
+        when(groupSettingsService.getSettings()).thenReturn(settings);
+        when(groupSettingsService.save(any(GroupSettings.class))).thenThrow(new RuntimeException("DB error"));
+
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
+        ui.add(view);
+
+        try (org.mockito.MockedStatic<AppNotification> mocked = mockStatic(AppNotification.class)) {
+            mocked.when(() -> AppNotification.error(anyString())).thenAnswer(inv -> null);
+            VerticalLayout integrationsTab = view.createIntegrationsTabContent();
+            Button saveBtn = firstComponent(integrationsTab, Button.class, b -> "Save".equals(b.getText()));
+            saveBtn.click();
+            mocked.verify(() -> AppNotification.error(anyString()));
+        }
+    }
+
     private <T extends Component> boolean anyComponent(Component root, Class<T> type, Predicate<T> predicate) {
         return findComponents(root, type).stream().anyMatch(predicate);
     }

--- a/src/test/java/com/afitnerd/tnra/vaadin/AdminViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/AdminViewTest.java
@@ -4,8 +4,10 @@ import com.afitnerd.tnra.model.GoToGuyPair;
 import com.afitnerd.tnra.model.GoToGuySet;
 import com.afitnerd.tnra.model.StatDefinition;
 import com.afitnerd.tnra.model.User;
+import com.afitnerd.tnra.model.GroupSettings;
 import com.afitnerd.tnra.repository.PersonalStatDefinitionRepository;
 import com.afitnerd.tnra.repository.StatDefinitionRepository;
+import com.afitnerd.tnra.service.GroupSettingsService;
 import com.afitnerd.tnra.service.UserService;
 import com.afitnerd.tnra.vaadin.presenter.CallChainPresenter;
 import com.afitnerd.tnra.vaadin.presenter.VaadinAdminPresenter;
@@ -68,6 +70,9 @@ class AdminViewTest {
     @Mock
     private UserService userService;
 
+    @Mock
+    private GroupSettingsService groupSettingsService;
+
     private UI ui;
 
     @BeforeEach
@@ -89,6 +94,7 @@ class AdminViewTest {
         lenient().when(userService.getAllActiveUsers()).thenReturn(List.of());
         lenient().when(userService.getAllUsers()).thenReturn(List.of());
         lenient().when(userService.getCurrentUser()).thenReturn(null);
+        lenient().when(groupSettingsService.getSettings()).thenReturn(new GroupSettings());
     }
 
     @AfterEach
@@ -100,7 +106,7 @@ class AdminViewTest {
     void buildsHeaderTabsAndCurrentSetGrid() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(sampleSet());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         assertTrue(view.hasClassName("admin-view"));
         assertTrue(anyComponent(view, H2.class, h -> "Admin Dashboard".equals(h.getText())));
@@ -116,7 +122,7 @@ class AdminViewTest {
         newSet.setGoToGuyPairs(new ArrayList<>());
         when(callChainPresenter.createNewGoToGuySet(anyList())).thenReturn(newSet);
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
         Button createButton = firstComponent(view, Button.class, b -> "Create New Go To Guy Set".equals(b.getText()));
         Button addPairButton = firstComponent(view, Button.class, b -> "Add Pair".equals(b.getText()));
@@ -136,7 +142,7 @@ class AdminViewTest {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(sampleSet());
         when(callChainPresenter.createNewGoToGuySet(anyList())).thenThrow(new RuntimeException("boom"));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
         Button createButton = firstComponent(view, Button.class, b -> "Create New Go To Guy Set".equals(b.getText()));
 
@@ -147,7 +153,7 @@ class AdminViewTest {
     @Test
     void getUserDisplayNameHandlesAllFallbacks() throws Exception {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         Method method = AdminView.class.getDeclaredMethod("getUserDisplayName", User.class);
         method.setAccessible(true);
@@ -191,7 +197,7 @@ class AdminViewTest {
         bFresh.setId(20L);
 
         when(statDefinitionRepository.findGlobalAllOrderByDisplayOrderAsc()).thenReturn(List.of());
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         Method method = AdminView.class.getDeclaredMethod("findActiveIndex", List.class, StatDefinition.class);
         method.setAccessible(true);
@@ -226,7 +232,7 @@ class AdminViewTest {
         when(statDefinitionRepository.findGlobalActiveOrderByDisplayOrderAsc())
             .thenReturn(new ArrayList<>(List.of(a, b)));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         VerticalLayout statsList = new VerticalLayout();
         view.moveStatUp(b, statsList);
@@ -248,7 +254,7 @@ class AdminViewTest {
         when(statDefinitionRepository.findGlobalActiveOrderByDisplayOrderAsc())
             .thenReturn(new ArrayList<>(List.of(a)));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         VerticalLayout statsList = new VerticalLayout();
         view.moveStatUp(a, statsList);
@@ -270,7 +276,7 @@ class AdminViewTest {
         when(statDefinitionRepository.findGlobalActiveOrderByDisplayOrderAsc())
             .thenReturn(new ArrayList<>(List.of(a, b)));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         VerticalLayout statsList = new VerticalLayout();
         view.moveStatDown(a, statsList);
@@ -292,7 +298,7 @@ class AdminViewTest {
         when(statDefinitionRepository.findGlobalActiveOrderByDisplayOrderAsc())
             .thenReturn(new ArrayList<>(List.of(a)));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         VerticalLayout statsList = new VerticalLayout();
         view.moveStatDown(a, statsList);
@@ -319,7 +325,7 @@ class AdminViewTest {
         when(statDefinitionRepository.findGlobalActiveOrderByDisplayOrderAsc())
             .thenReturn(new ArrayList<>(List.of(a, b)));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         VerticalLayout statsList = new VerticalLayout();
         view.archiveStat(a, statsList);
@@ -340,7 +346,7 @@ class AdminViewTest {
         when(statDefinitionRepository.findGlobalActiveOrderByDisplayOrderAsc())
             .thenReturn(new ArrayList<>(List.of(a)));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         VerticalLayout statsList = new VerticalLayout();
         view.archiveStat(a, statsList);
@@ -370,7 +376,7 @@ class AdminViewTest {
         when(statDefinitionRepository.findGlobalActiveOrderByDisplayOrderAsc())
             .thenReturn(new ArrayList<>(List.of(active)));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         VerticalLayout statsList = new VerticalLayout();
         view.restoreStat(archived, statsList);
@@ -392,7 +398,7 @@ class AdminViewTest {
         when(statDefinitionRepository.findGlobalActiveOrderByDisplayOrderAsc())
             .thenReturn(new ArrayList<>());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         VerticalLayout statsList = new VerticalLayout();
         view.restoreStat(archived, statsList);
@@ -411,7 +417,7 @@ class AdminViewTest {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
         when(statDefinitionRepository.findGlobalAllOrderByDisplayOrderAsc()).thenReturn(List.of());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         VerticalLayout statsList = new VerticalLayout();
         view.refreshStatsList(statsList);
@@ -439,7 +445,7 @@ class AdminViewTest {
         when(statDefinitionRepository.findGlobalActiveOrderByDisplayOrderAsc())
             .thenReturn(List.of(active));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         VerticalLayout statsList = new VerticalLayout();
         view.refreshStatsList(statsList);
@@ -456,7 +462,7 @@ class AdminViewTest {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
         when(statDefinitionRepository.findGlobalAllOrderByDisplayOrderAsc()).thenReturn(List.of());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         VerticalLayout statsList = new VerticalLayout();
         assertDoesNotThrow(() -> view.openAddStatDialog(statsList));
@@ -471,7 +477,7 @@ class AdminViewTest {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
         when(statDefinitionRepository.findGlobalAllOrderByDisplayOrderAsc()).thenReturn(List.of());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         com.vaadin.flow.component.grid.Grid<User> membersGrid = new com.vaadin.flow.component.grid.Grid<>();
         assertDoesNotThrow(() -> view.openInviteMemberDialog(membersGrid));
@@ -486,7 +492,7 @@ class AdminViewTest {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
         when(statDefinitionRepository.findGlobalAllOrderByDisplayOrderAsc()).thenReturn(List.of());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         // Should not throw
         assertDoesNotThrow(() -> view.showValidationError(null, null, List.of()));
@@ -497,7 +503,7 @@ class AdminViewTest {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
         when(statDefinitionRepository.findGlobalAllOrderByDisplayOrderAsc()).thenReturn(List.of());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User user = new User();
         user.setId(1L);
@@ -511,7 +517,7 @@ class AdminViewTest {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
         when(statDefinitionRepository.findGlobalAllOrderByDisplayOrderAsc()).thenReturn(List.of());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User caller = new User();
         caller.setId(1L);
@@ -535,7 +541,7 @@ class AdminViewTest {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
         when(statDefinitionRepository.findGlobalAllOrderByDisplayOrderAsc()).thenReturn(List.of());
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User caller = new User();
         caller.setId(1L);
@@ -572,7 +578,7 @@ class AdminViewTest {
 
         // Constructing the view exercises the component column lambda which creates
         // Deactivate buttons for active non-self users
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         // Verify the grid was populated with users
@@ -600,7 +606,7 @@ class AdminViewTest {
 
         // Constructing the view exercises the component column lambda which creates
         // Reactivate buttons for inactive non-self users
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         verify(userService).getAllUsers();
@@ -619,7 +625,7 @@ class AdminViewTest {
         when(userService.getAllUsers()).thenReturn(List.of(currentUser));
 
         // Constructing the view with only the self user covers the isSelf branch
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         verify(userService).getCurrentUser();
@@ -639,7 +645,7 @@ class AdminViewTest {
         when(userService.getCurrentUser()).thenReturn(null);
         when(userService.getAllUsers()).thenReturn(List.of(userWithName));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         // View construction exercises the name column lambda with first + last name
@@ -658,7 +664,7 @@ class AdminViewTest {
         when(userService.getCurrentUser()).thenReturn(null);
         when(userService.getAllUsers()).thenReturn(List.of(userNoName));
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         // View construction exercises the name column lambda with null first/last name
@@ -669,7 +675,7 @@ class AdminViewTest {
     void refreshMembersGridCallsGetAllUsers() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         Grid<User> grid = new Grid<>();
         view.refreshMembersGrid(grid);
@@ -690,7 +696,7 @@ class AdminViewTest {
         newSet.setGoToGuyPairs(new ArrayList<>());
         when(callChainPresenter.createNewGoToGuySet(anyList())).thenReturn(newSet);
 
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
         ui.add(view);
 
         Button createButton = firstComponent(view, Button.class, b -> "Create New Go To Guy Set".equals(b.getText()));
@@ -716,7 +722,7 @@ class AdminViewTest {
     @Test
     void formatMemberNameReturnsFirstAndLastName() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User user = new User();
         user.setFirstName("Jane");
@@ -727,7 +733,7 @@ class AdminViewTest {
     @Test
     void formatMemberNameReturnsFirstNameOnlyWhenLastNull() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User user = new User();
         user.setFirstName("Jane");
@@ -737,7 +743,7 @@ class AdminViewTest {
     @Test
     void formatMemberNameReturnsNotYetLoggedInWhenNoName() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User user = new User();
         assertEquals("(not yet logged in)", view.formatMemberName(user));
@@ -750,7 +756,7 @@ class AdminViewTest {
     @Test
     void formatMemberStatusReturnsActiveForActiveUser() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User user = new User();
         user.setActive(true);
@@ -760,7 +766,7 @@ class AdminViewTest {
     @Test
     void formatMemberStatusReturnsInactiveForInactiveUser() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User user = new User();
         user.setActive(false);
@@ -774,7 +780,7 @@ class AdminViewTest {
     @Test
     void createMemberActionComponentReturnsSelfSpan() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User self = new User();
         self.setId(1L);
@@ -787,7 +793,7 @@ class AdminViewTest {
     @Test
     void createMemberActionComponentReturnsDeactivateButtonForActiveNonSelf() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User currentUser = new User(); currentUser.setId(1L);
         User other = new User(); other.setId(2L); other.setActive(true);
@@ -801,7 +807,7 @@ class AdminViewTest {
     @Test
     void createMemberActionComponentReturnsReactivateButtonForInactiveNonSelf() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User currentUser = new User(); currentUser.setId(1L);
         User other = new User(); other.setId(2L); other.setActive(false);
@@ -815,7 +821,7 @@ class AdminViewTest {
     @Test
     void createMemberActionComponentNullCurrentUserNotSelf() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User other = new User(); other.setId(2L); other.setActive(true);
         com.vaadin.flow.component.grid.Grid<User> grid = new com.vaadin.flow.component.grid.Grid<>();
@@ -828,7 +834,7 @@ class AdminViewTest {
     @Test
     void createMemberActionComponentDeactivateButtonClickCallsService() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User currentUser = new User(); currentUser.setId(1L);
         User other = new User(); other.setId(2L); other.setActive(true); other.setFirstName("Bob");
@@ -845,7 +851,7 @@ class AdminViewTest {
     @Test
     void createMemberActionComponentReactivateButtonClickCallsService() {
         when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(null);
-        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService);
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
 
         User currentUser = new User(); currentUser.setId(1L);
         User other = new User(); other.setId(2L); other.setActive(false); other.setFirstName("Bob");
@@ -874,6 +880,52 @@ class AdminViewTest {
         GoToGuySet set = new GoToGuySet();
         set.setGoToGuyPairs(List.of(pair));
         return set;
+    }
+
+    // ========================
+    // Integrations Tab Tests
+    // ========================
+
+    @Test
+    void integrationsTabContentLoadsWithNoExistingSettings() {
+        when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(sampleSet());
+        when(groupSettingsService.getSettings()).thenReturn(new GroupSettings());
+
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
+
+        VerticalLayout integrationsTab = view.createIntegrationsTabContent();
+        assertNotNull(integrationsTab);
+    }
+
+    @Test
+    void integrationsTabContentLoadsWithExistingSettings() {
+        when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(sampleSet());
+        GroupSettings settings = new GroupSettings();
+        settings.setSlackWebhookUrl("https://hooks.slack.com/test");
+        settings.setSlackEnabled(true);
+        when(groupSettingsService.getSettings()).thenReturn(settings);
+
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
+
+        VerticalLayout integrationsTab = view.createIntegrationsTabContent();
+        assertNotNull(integrationsTab);
+    }
+
+    @Test
+    void integrationsTabSaveButtonCallsGroupSettingsService() {
+        when(callChainPresenter.getCurrentGoToGuySet()).thenReturn(sampleSet());
+        GroupSettings settings = new GroupSettings();
+        when(groupSettingsService.getSettings()).thenReturn(settings);
+        when(groupSettingsService.save(any(GroupSettings.class))).thenReturn(settings);
+
+        AdminView view = new AdminView(vaadinAdminPresenter, callChainPresenter, statDefinitionRepository, personalStatDefinitionRepository, userService, groupSettingsService);
+        ui.add(view);
+
+        VerticalLayout integrationsTab = view.createIntegrationsTabContent();
+        Button saveBtn = firstComponent(integrationsTab, Button.class, b -> "Save".equals(b.getText()));
+        saveBtn.click();
+
+        verify(groupSettingsService).save(any(GroupSettings.class));
     }
 
     private <T extends Component> boolean anyComponent(Component root, Class<T> type, Predicate<T> predicate) {

--- a/src/test/java/com/afitnerd/tnra/vaadin/PostViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/PostViewTest.java
@@ -3,6 +3,7 @@ package com.afitnerd.tnra.vaadin;
 import com.afitnerd.tnra.model.Post;
 import com.afitnerd.tnra.model.PostState;
 import com.afitnerd.tnra.model.User;
+import com.afitnerd.tnra.service.PostTokenService;
 import com.afitnerd.tnra.vaadin.presenter.VaadinPostPresenter;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.UI;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class for PostView that exercises various modes and UI states:
@@ -56,6 +58,9 @@ class PostViewTest {
 
     @Mock
     private VaadinPostPresenter vaadinPostPresenter;
+
+    @Mock
+    private PostTokenService postTokenService;
     
     @Mock
     private UI mockUI;
@@ -118,7 +123,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
             
             // Force switch to completed posts view
@@ -143,7 +148,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Assert: Should have switch button, date/time display, and finish button
@@ -164,7 +169,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Assert: Should be in completed view with dropdown, pagination, and start button
@@ -187,7 +192,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Assert: Cannot switch to in-progress view (no switch button available)
@@ -214,7 +219,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Initial state: in-progress view
@@ -277,7 +282,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Act
@@ -300,7 +305,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Act
@@ -321,7 +326,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Assert
@@ -339,7 +344,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Act
@@ -360,7 +365,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Assert
@@ -377,7 +382,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Act
@@ -397,7 +402,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Assert - Check that form contains expected sections
@@ -409,14 +414,14 @@ class PostViewTest {
     void testPostViewConstructor() {
         // Act & Assert
         assertDoesNotThrow(() -> {
-            new PostView(vaadinPostPresenter);
+            new PostView(vaadinPostPresenter, postTokenService);
         });
     }
 
     @Test
     void testPostViewSizeAndClassNames() {
         // Act
-        PostView view = new PostView(vaadinPostPresenter);
+        PostView view = new PostView(vaadinPostPresenter, postTokenService);
 
         // Assert
         assertTrue(view.getClassNames().contains("post-view"));
@@ -431,7 +436,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Act - We can't test the private method directly, but we can test that
@@ -449,7 +454,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
             
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Act - We can test that completed posts are handled
@@ -463,13 +468,14 @@ class PostViewTest {
         // Arrange: deep link to a completed post
         lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.empty());
         lenient().when(vaadinPostPresenter.getPostById(2L)).thenReturn(Optional.of(completedPost1));
+        when(postTokenService.decode("token-2")).thenReturn(2L);
 
         try (MockedStatic<UI> mockedUI = mockStatic(UI.class)) {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
-            postView.setParameter(mock(BeforeEvent.class), 2L);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
+            postView.setParameter(mock(BeforeEvent.class), "token-2");
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Assert: should be in completed posts mode with the deep-linked post loaded
@@ -483,13 +489,14 @@ class PostViewTest {
         // Arrange: deep link to current user's own in-progress post
         lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.of(inProgressPost));
         lenient().when(vaadinPostPresenter.getPostById(1L)).thenReturn(Optional.of(inProgressPost));
+        when(postTokenService.decode("token-1")).thenReturn(1L);
 
         try (MockedStatic<UI> mockedUI = mockStatic(UI.class)) {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
-            postView.setParameter(mock(BeforeEvent.class), 1L);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
+            postView.setParameter(mock(BeforeEvent.class), "token-1");
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Assert: should show in-progress view for own in-progress post
@@ -502,13 +509,14 @@ class PostViewTest {
         // Arrange: deep link to a non-existent post
         lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.empty());
         lenient().when(vaadinPostPresenter.getPostById(999L)).thenReturn(Optional.empty());
+        when(postTokenService.decode("token-999")).thenReturn(999L);
 
         try (MockedStatic<UI> mockedUI = mockStatic(UI.class)) {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
-            postView.setParameter(mock(BeforeEvent.class), 999L);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
+            postView.setParameter(mock(BeforeEvent.class), "token-999");
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Assert: should fall through to default behavior (no in-progress → completed view)
@@ -526,7 +534,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.setParameter(mock(BeforeEvent.class), null);
             postView.afterNavigation(mockAfterNavigationEvent());
 
@@ -548,13 +556,14 @@ class PostViewTest {
 
         lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.empty());
         lenient().when(vaadinPostPresenter.getPostById(20L)).thenReturn(Optional.of(otherInProgressPost));
+        when(postTokenService.decode("token-20")).thenReturn(20L);
 
         try (MockedStatic<UI> mockedUI = mockStatic(UI.class)) {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
-            postView.setParameter(mock(BeforeEvent.class), 20L);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
+            postView.setParameter(mock(BeforeEvent.class), "token-20");
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Assert: should fall through to default behavior, NOT show the other user's post
@@ -577,13 +586,14 @@ class PostViewTest {
         lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.empty());
         lenient().when(vaadinPostPresenter.getPostById(10L)).thenReturn(Optional.of(otherUserPost));
         lenient().when(vaadinPostPresenter.getCompletedPostsPage(eq(otherUser), any(Pageable.class))).thenReturn(new PageImpl<>(Arrays.asList(otherUserPost)));
+        when(postTokenService.decode("token-10")).thenReturn(10L);
 
         try (MockedStatic<UI> mockedUI = mockStatic(UI.class)) {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
-            postView.setParameter(mock(BeforeEvent.class), 10L);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
+            postView.setParameter(mock(BeforeEvent.class), "token-10");
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Assert: should show completed view for the other user's post
@@ -614,7 +624,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Find and click the next page button
@@ -647,7 +657,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Go to next page first
@@ -684,7 +694,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Go to next page first
@@ -719,7 +729,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Go to last page
@@ -750,7 +760,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Find the page number field and set value to page 2
@@ -777,7 +787,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // All pagination buttons should be disabled on a single page
@@ -823,7 +833,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Call finishPost directly via reflection (button is disabled until all fields filled)
@@ -849,7 +859,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Invoke updateFinishButtonState via reflection
@@ -873,7 +883,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Fill only intro fields via the form fields
@@ -898,7 +908,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Switch to showing completed posts so button should be disabled
@@ -922,7 +932,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Fill all text fields
@@ -950,7 +960,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Call generatePostLabel via reflection with null
@@ -968,7 +978,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             String label = invokeGeneratePostLabel(postView, inProgressPost);
@@ -985,7 +995,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             String label = invokeGeneratePostLabel(postView, completedPost1);
@@ -1012,7 +1022,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             String label = invokeGeneratePostLabel(postView, noFinishPost);
@@ -1035,7 +1045,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Find and update a text field — this should trigger the binder value change listener
@@ -1061,7 +1071,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Update a field — should trigger save which throws, but should be handled gracefully
@@ -1085,7 +1095,7 @@ class PostViewTest {
             setupUIMocks("America/New_York");
             mockedUI.when(UI::getCurrent).thenReturn(mockUI);
 
-            postView = new PostView(vaadinPostPresenter);
+            postView = new PostView(vaadinPostPresenter, postTokenService);
             postView.afterNavigation(mockAfterNavigationEvent());
 
             // Access the page size selector via reflection
@@ -1317,6 +1327,24 @@ class PostViewTest {
             }
         }
         return null;
+    }
+
+    @Test
+    void testDeepLinkWithInvalidTokenFallsThroughToDefault() {
+        when(postTokenService.decode("INVALID")).thenThrow(new IllegalArgumentException("bad token"));
+        lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.of(inProgressPost));
+
+        try (MockedStatic<UI> mockedUI = mockStatic(UI.class)) {
+            setupUIMocks("America/New_York");
+            mockedUI.when(UI::getCurrent).thenReturn(mockUI);
+
+            postView = new PostView(vaadinPostPresenter, postTokenService);
+            postView.setParameter(mock(BeforeEvent.class), "INVALID");
+            postView.afterNavigation(mockAfterNavigationEvent());
+
+            assertFalse(postView.showingCompletedPosts, "Invalid token should fall through to in-progress default");
+            verify(postTokenService).decode("INVALID");
+        }
     }
 
     private void setupUIMocks(String timeZoneId) {

--- a/src/test/java/com/afitnerd/tnra/vaadin/PostViewTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/PostViewTest.java
@@ -1347,6 +1347,27 @@ class PostViewTest {
         }
     }
 
+    @Test
+    void testDeepLinkWithNullUserFallsThroughToDefault() {
+        Post postWithNullUser = new Post();
+        postWithNullUser.setId(77L);
+        // user is null
+        lenient().when(vaadinPostPresenter.getOptionalInProgressPost(testUser)).thenReturn(Optional.empty());
+        when(vaadinPostPresenter.getPostById(77L)).thenReturn(Optional.of(postWithNullUser));
+        when(postTokenService.decode("token-77")).thenReturn(77L);
+
+        try (MockedStatic<UI> mockedUI = mockStatic(UI.class)) {
+            setupUIMocks("America/New_York");
+            mockedUI.when(UI::getCurrent).thenReturn(mockUI);
+
+            postView = new PostView(vaadinPostPresenter, postTokenService);
+            postView.setParameter(mock(BeforeEvent.class), "token-77");
+            postView.afterNavigation(mockAfterNavigationEvent());
+
+            assertTrue(postView.showingCompletedPosts, "Post with null user should fall through to default");
+        }
+    }
+
     private void setupUIMocks(String timeZoneId) {
         // Setup the mock chain: UI.getCurrent().getSession().getAttribute(ExtendedClientDetails.class)
         lenient().when(mockUI.getSession()).thenReturn(mockSession);

--- a/src/test/java/com/afitnerd/tnra/vaadin/presenter/VaadinPostPresenterImplTest.java
+++ b/src/test/java/com/afitnerd/tnra/vaadin/presenter/VaadinPostPresenterImplTest.java
@@ -9,6 +9,7 @@ import com.afitnerd.tnra.repository.StatDefinitionRepository;
 import com.afitnerd.tnra.service.EMailService;
 import com.afitnerd.tnra.service.OidcUserService;
 import com.afitnerd.tnra.service.PostService;
+import com.afitnerd.tnra.service.SlackNotificationService;
 import com.afitnerd.tnra.service.UserService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -35,6 +36,7 @@ class VaadinPostPresenterImplTest {
     private UserService userService;
     private PostService postService;
     private EMailService emailService;
+    private SlackNotificationService slackNotificationService;
     private PostRepository postRepository;
     private StatDefinitionRepository statDefinitionRepository;
     private PersonalStatDefinitionRepository personalStatDefinitionRepository;
@@ -46,11 +48,13 @@ class VaadinPostPresenterImplTest {
         userService = mock(UserService.class);
         postService = mock(PostService.class);
         emailService = mock(EMailService.class);
+        slackNotificationService = mock(SlackNotificationService.class);
         postRepository = mock(PostRepository.class);
         statDefinitionRepository = mock(StatDefinitionRepository.class);
         personalStatDefinitionRepository = mock(PersonalStatDefinitionRepository.class);
         presenter = new VaadinPostPresenterImpl(
-            oidcUserService, userService, postService, emailService, postRepository, statDefinitionRepository, personalStatDefinitionRepository
+            oidcUserService, userService, postService, emailService, slackNotificationService,
+            postRepository, statDefinitionRepository, personalStatDefinitionRepository
         );
     }
 
@@ -68,6 +72,18 @@ class VaadinPostPresenterImplTest {
         setField(presenter, "emailServiceEnabled", false);
         presenter.finishPost(user);
         verify(emailService, org.mockito.Mockito.times(1)).sendMailToAll(post);
+    }
+
+    @Test
+    void finishPostAlwaysCallsSlackNotification() throws Exception {
+        User user = new User();
+        Post post = new Post();
+        when(postService.finishPost(user)).thenReturn(post);
+        setField(presenter, "emailServiceEnabled", false);
+
+        presenter.finishPost(user);
+
+        verify(slackNotificationService).sendActivityNotification(post);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds Slack incoming webhook support: when a member finishes a post, a fire-and-forget notification is sent with username, start time, finish time, and a deep link to the post. No post content leaves the encrypted database.
- New `group_settings` table (V11 Flyway migration) stores the webhook URL (AES-256-GCM encrypted) and an enabled flag.
- New **Integrations** tab in AdminView lets admins configure the webhook URL and toggle it on/off.
- Async execution uses a dedicated 2-thread `slackTaskExecutor` with CallerRunsPolicy and 15s graceful shutdown; errors are logged and never surface to the user.

## Changes

| Area | What changed |
|---|---|
| DB | `V11__group_settings.sql` — new `group_settings` table |
| Model | `GroupSettings` entity with `@Convert(EncryptedStringConverter)` on webhook URL |
| Repository | `GroupSettingsRepository` with `findFirstByOrderByIdAsc()` |
| Service | `GroupSettingsService` / `GroupSettingsServiceImpl` — single-row settings access |
| Service | `SlackNotificationService` / `SlackNotificationServiceImpl` — async HTTP POST, extracted `doPost()` for testability |
| UI | `AdminView` — new Integrations tab with URL field, enable checkbox, save button |
| Presenter | `VaadinPostPresenterImpl.finishPost()` wired to call Slack after email |
| App | `TnraApplication` — `slackTaskExecutor` thread pool bean |
| Tests | 3 new test classes; `AdminViewTest`, `AdminViewDialogTest`, `VaadinPostPresenterImplTest` updated |
| Docs | `TODOS.md` updated — Slack Part 1 marked complete |

## Test plan

- [ ] `./mvnw clean test` — all tests pass, JaCoCo ≥ 95%
- [ ] Slack disabled (default): no HTTP call made, debug log emitted
- [ ] Slack enabled, blank URL: early exit, debug log emitted
- [ ] Slack enabled, valid URL: async POST fires, info log emitted
- [ ] IOException from POST: error logged, no exception propagates to caller
- [ ] AdminView Integrations tab renders with URL field and enabled checkbox
- [ ] Save in Integrations tab persists settings via `GroupSettingsService`

🤖 Generated with [Claude Code](https://claude.com/claude-code)